### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/src/DBMLib/lib.rs
+++ b/src/DBMLib/lib.rs
@@ -28,7 +28,7 @@ pub const DBM_INF: i32 = i32::MAX - 1;
 /// ```
 pub fn rs_dbm_is_valid(dbm: &mut [i32], dimension: u32) -> bool {
     println!("IN DBM IS VALID");
-    representations::print_DBM(dbm, &dimension);
+    representations::print_DBM(dbm, dimension);
     let first = dbm.get(0).unwrap();
     if first == &-1 {
         return false;
@@ -607,7 +607,7 @@ pub fn rs_dbm_update(dbm: &mut [i32], dimension: u32, var_index: u32, value: i32
  */
 pub fn rs_dbm_isSubsetEq(dbm1: &mut [i32], dbm2: &mut [i32], dimension: u32) -> bool {
     println!("printing from subseteq");
-    representations::print_DBM(dbm1, &dimension);
+    representations::print_DBM(dbm1, dimension);
     unsafe { return BOOL_TRUE == dbm_isSubsetEq(dbm1.as_mut_ptr(), dbm2.as_mut_ptr(), dimension) }
 }
 

--- a/src/DataReader/json_reader.rs
+++ b/src/DataReader/json_reader.rs
@@ -1,5 +1,5 @@
-use super::super::ModelObjects::component;
-use super::super::ModelObjects::queries;
+use crate::ModelObjects::component;
+use crate::ModelObjects::queries;
 use serde::de::DeserializeOwned;
 use serde_json::Result;
 use std::fs::File;
@@ -13,35 +13,35 @@ pub fn read_json<T: DeserializeOwned>(filename: String) -> Result<T> {
     let mut data = String::new();
     file.read_to_string(&mut data).unwrap();
 
-    let output: String = filename + ": Json format is not as expected";
-    let json_file: T = serde_json::from_str(&data).expect(output.as_str());
+    let json_file = serde_json::from_str(&data)
+        .unwrap_or_else(|_| panic!("{}: Json format is not as expected", filename));
 
     Ok(json_file)
 }
+
 //Input:Filename
 //Description:Transforms json into component type
 //Output:Result type
 pub fn json_to_component(filename: String) -> Result<component::Component> {
-    let filenamecopy = filename.clone();
-    let json: component::Component = match read_json::<component::Component>(filename) {
+    let json = match read_json(filename.clone()) {
         Ok(json) => json,
         Err(error) => panic!(
             "We got error {}, and could not parse json file {} to component",
-            error, filenamecopy
+            error, filename
         ),
     };
     Ok(json)
 }
+
 //Input:Filename
 //Description: transforms json into query type
 //Output:Result
 pub fn json_to_query(filename: String) -> Result<Vec<queries::Query>> {
-    let filenamecopy = filename.clone();
-    let json: Vec<queries::Query> = match read_json::<Vec<queries::Query>>(filename) {
+    let json = match read_json(filename.clone()) {
         Ok(json) => json,
         Err(error) => panic!(
             "We got error {}, and could not parse json file {} to query",
-            error, filenamecopy
+            error, filename
         ),
     };
     Ok(json)

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -1,4 +1,4 @@
-use super::super::DBMLib::lib;
+use crate::DBMLib::lib;
 use crate::ModelObjects::component;
 use crate::ModelObjects::representations;
 use crate::ModelObjects::representations::BoolExpression;
@@ -7,7 +7,7 @@ pub fn apply_constraints_to_state(
     guard: &BoolExpression,
     state: &component::State,
     zone: &mut [i32],
-    dimensions: &u32,
+    dimensions: u32,
 ) -> bool {
     if let BoolExpression::Bool(val) =
         apply_constraints_to_state_helper(guard, state, zone, dimensions, true).0
@@ -22,7 +22,7 @@ pub fn apply_constraints_to_state_helper(
     guard: &BoolExpression,
     state: &component::State,
     zone: &mut [i32],
-    dimensions: &u32,
+    dimensions: u32,
     should_apply: bool,
 ) -> (BoolExpression, bool) {
     match guard {
@@ -95,7 +95,7 @@ pub fn apply_constraints_to_state_helper(
                         BoolExpression::Clock(right_index) => {
                             let result = lib::rs_dbm_add_LTE_constraint(
                                 zone,
-                                *dimensions,
+                                dimensions,
                                 left_index,
                                 right_index,
                                 0,
@@ -107,11 +107,7 @@ pub fn apply_constraints_to_state_helper(
                         BoolExpression::Int(right_val) => {
                             //println!("Clock index: {:?} og bound: {:?}", left_index, right_val);
                             let result = lib::rs_dbm_add_LTE_constraint(
-                                zone,
-                                *dimensions,
-                                left_index,
-                                0,
-                                right_val,
+                                zone, dimensions, left_index, 0, right_val,
                             );
                             return (BoolExpression::Bool(result), false);
                         }
@@ -124,7 +120,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             0,
                             right_index,
                             -1 * left_val,
@@ -160,7 +156,7 @@ pub fn apply_constraints_to_state_helper(
                         BoolExpression::Clock(right_index) => {
                             let result = lib::rs_dbm_add_LTE_constraint(
                                 zone,
-                                *dimensions,
+                                dimensions,
                                 right_index,
                                 left_index,
                                 0,
@@ -171,7 +167,7 @@ pub fn apply_constraints_to_state_helper(
                         BoolExpression::Int(right_val) => {
                             let result = lib::rs_dbm_add_LTE_constraint(
                                 zone,
-                                *dimensions,
+                                dimensions,
                                 0,
                                 left_index,
                                 -1 * right_val,
@@ -187,7 +183,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             right_index,
                             0,
                             left_val,
@@ -223,7 +219,7 @@ pub fn apply_constraints_to_state_helper(
                         BoolExpression::Clock(right_index) => {
                             let result = lib::rs_dbm_add_EQ_constraint(
                                 zone,
-                                *dimensions,
+                                dimensions,
                                 right_index,
                                 left_index,
                             );
@@ -231,10 +227,7 @@ pub fn apply_constraints_to_state_helper(
                         }
                         BoolExpression::Int(right_val) => {
                             let result = lib::rs_dbm_add_EQ_const_constraint(
-                                zone,
-                                *dimensions,
-                                left_index,
-                                right_val,
+                                zone, dimensions, left_index, right_val,
                             );
                             return (BoolExpression::Bool(result), false);
                         }
@@ -247,7 +240,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_EQ_const_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             right_index,
                             left_val,
                         );
@@ -280,7 +273,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             left_index,
                             right_index,
                             0,
@@ -289,11 +282,7 @@ pub fn apply_constraints_to_state_helper(
                     }
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LT_constraint(
-                            zone,
-                            *dimensions,
-                            left_index,
-                            0,
-                            right_val,
+                            zone, dimensions, left_index, 0, right_val,
                         );
                         return (BoolExpression::Bool(result), false);
                     }
@@ -305,7 +294,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             0,
                             right_index,
                             -1 * left_val,
@@ -338,7 +327,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             right_index,
                             left_index,
                             0,
@@ -348,7 +337,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             0,
                             left_index,
                             -1 * right_val,
@@ -363,7 +352,7 @@ pub fn apply_constraints_to_state_helper(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             zone,
-                            *dimensions,
+                            dimensions,
                             right_index,
                             0,
                             left_val,
@@ -393,8 +382,6 @@ pub fn apply_constraints_to_state_helper(
             } else {
                 panic!("No clock or variable named {:?} was found", name)
             }
-
-            panic!("could not find variable: {:?} in declarations", name);
         }
         BoolExpression::Bool(val) => return (BoolExpression::Bool(*val), false),
         BoolExpression::Int(val) => return (BoolExpression::Int(*val), false),
@@ -404,7 +391,7 @@ pub fn apply_constraints_to_state_helper(
 pub fn apply_constraints_to_state2(
     guard: &BoolExpression,
     full_state: &mut component::FullState,
-    dimensions: &u32,
+    dimensions: u32,
 ) -> BoolExpression {
     match guard {
         BoolExpression::AndOp(left, right) => {
@@ -457,7 +444,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             left_index,
                             right_index,
                             0,
@@ -467,7 +454,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             left_index,
                             0,
                             right_val,
@@ -482,7 +469,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             0,
                             right_index,
                             -1 * left_val,
@@ -509,7 +496,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             right_index,
                             left_index,
                             0,
@@ -519,7 +506,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             0,
                             left_index,
                             -1 * right_val,
@@ -534,7 +521,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LTE_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             right_index,
                             0,
                             left_val,
@@ -562,7 +549,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             left_index,
                             right_index,
                             0,
@@ -572,7 +559,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             left_index,
                             0,
                             right_val,
@@ -587,7 +574,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             0,
                             right_index,
                             -1 * left_val,
@@ -614,7 +601,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             right_index,
                             left_index,
                             0,
@@ -624,7 +611,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Int(right_val) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             0,
                             left_index,
                             -1 * right_val,
@@ -639,7 +626,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_LT_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             right_index,
                             0,
                             left_val,
@@ -696,7 +683,7 @@ pub fn apply_constraints_to_state2(
                         BoolExpression::Clock(right_index) => {
                             let result = lib::rs_dbm_add_EQ_constraint(
                                 full_state.get_zone(),
-                                *dimensions,
+                                dimensions,
                                 right_index,
                                 left_index,
                             );
@@ -705,7 +692,7 @@ pub fn apply_constraints_to_state2(
                         BoolExpression::Int(right_val) => {
                             let result = lib::rs_dbm_add_EQ_const_constraint(
                                 full_state.get_zone(),
-                                *dimensions,
+                                dimensions,
                                 left_index,
                                 right_val,
                             );
@@ -720,7 +707,7 @@ pub fn apply_constraints_to_state2(
                     BoolExpression::Clock(right_index) => {
                         let result = lib::rs_dbm_add_EQ_const_constraint(
                             full_state.get_zone(),
-                            *dimensions,
+                            dimensions,
                             right_index,
                             left_val,
                         );
@@ -739,6 +726,4 @@ pub fn apply_constraints_to_state2(
             }
         }
     }
-
-    //panic!("not implemented")
 }

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -1,6 +1,6 @@
-use super::super::ModelObjects::parse_edge;
 use crate::DBMLib::lib;
 use crate::ModelObjects::component;
+use crate::ModelObjects::parse_edge;
 use crate::ModelObjects::representations::BoolExpression;
 
 /// Used to handle update expressions on edges
@@ -33,7 +33,7 @@ pub fn updater(
 pub fn fullState_updater(
     updates: &Vec<parse_edge::Update>,
     full_state: &mut component::FullState,
-    dimension: &u32,
+    dimension: u32,
 ) {
     for update in updates {
         match update.get_expression() {
@@ -43,7 +43,7 @@ pub fn fullState_updater(
                     .get_declarations()
                     .get_clock_index_by_name(update.get_variable_name())
                 {
-                    lib::rs_dbm_update(full_state.get_zone(), *dimension, clock_index, *val);
+                    lib::rs_dbm_update(full_state.get_zone(), dimension, clock_index, *val);
                 } else {
                     panic!("Attempting to update a clock which is not initialized")
                 }

--- a/src/ModelObjects/parse_edge.rs
+++ b/src/ModelObjects/parse_edge.rs
@@ -1,5 +1,5 @@
 extern crate pest;
-use super::super::ModelObjects::representations::BoolExpression;
+use crate::ModelObjects::representations::BoolExpression;
 use pest::error::Error;
 use pest::Parser;
 use serde::export::Option::Some;
@@ -45,6 +45,7 @@ pub fn parse(edge_attribute_str: &str) -> Result<EdgeAttribute, Error<Rule>> {
         }
     }
 }
+
 pub fn build_edgeAttribute_from_pair(pair: pest::iterators::Pair<Rule>) -> EdgeAttribute {
     let pair = pair.into_inner().next().unwrap();
     match pair.as_rule() {
@@ -55,6 +56,7 @@ pub fn build_edgeAttribute_from_pair(pair: pest::iterators::Pair<Rule>) -> EdgeA
         }
     }
 }
+
 fn build_guard_from_pair(pair: pest::iterators::Pair<Rule>) -> EdgeAttribute {
     match pair.as_rule() {
         Rule::guard => {
@@ -126,15 +128,14 @@ fn build_assignments_from_pair(pair: pest::iterators::Pair<Rule>) -> Vec<Update>
 }
 
 fn build_assignment_from_pair(pair: pest::iterators::Pair<Rule>) -> Update {
-    let expression: BoolExpression;
     let mut inner_pairs = pair.into_inner();
     let variable = inner_pairs.next().unwrap().as_str();
     let expression_pair = inner_pairs.next().unwrap();
 
-    expression = build_expression_from_pair(expression_pair);
+    let expression = build_expression_from_pair(expression_pair);
     let update = Update {
         variable: variable.trim().to_string(),
-        expression: expression,
+        expression,
     };
 
     return update;

--- a/src/ModelObjects/parse_invariant.rs
+++ b/src/ModelObjects/parse_invariant.rs
@@ -1,11 +1,11 @@
 extern crate pest;
-use super::super::ModelObjects::representations::BoolExpression;
+use crate::ModelObjects::representations::BoolExpression;
 use pest::error::Error;
 use pest::Parser;
 use serde::export::Option::Some;
 
-///This file handles parsing the invariants based on the abstract syntax described in the .pest files in the grammar folder
-///For clarification see documentation on pest crate
+/// This file handles parsing the invariants based on the abstract syntax described in the .pest files in the grammar folder
+/// For clarification see documentation on pest crate
 #[derive(Parser)]
 #[grammar = "ModelObjects/grammars/invariant_grammar.pest"]
 pub struct InvariantParser;
@@ -28,7 +28,7 @@ pub fn build_invariant_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpre
         Rule::andExpr => {
             let pair_span = pair.as_span();
 
-            //check if we have an empty pair
+            // check if we have an empty pair
             if pair_span.start() == pair_span.end() {
                 return BoolExpression::Bool(true);
             }

--- a/src/ModelObjects/parse_queries.rs
+++ b/src/ModelObjects/parse_queries.rs
@@ -1,5 +1,5 @@
 extern crate pest;
-use super::super::ModelObjects::representations::QueryExpression;
+use crate::ModelObjects::representations::QueryExpression;
 use pest::error::Error;
 use pest::Parser;
 use serde::export::Option::Some;

--- a/src/ModelObjects/queries.rs
+++ b/src/ModelObjects/queries.rs
@@ -1,8 +1,8 @@
-use super::parse_queries;
-use super::representations;
+use crate::ModelObjects::parse_queries;
+use crate::ModelObjects::representations;
 use serde::{Deserialize, Deserializer};
 
-//The struct containing a single query
+/// The struct containing a single query
 #[derive(Debug, Deserialize)]
 pub struct Query {
     #[serde(deserialize_with = "decode_query")]
@@ -16,7 +16,7 @@ impl Query {
     }
 }
 
-//Function used for deserializing queries
+/// Function used for deserializing queries
 pub fn decode_query<'de, D>(
     deserializer: D,
 ) -> Result<Option<representations::QueryExpression>, D::Error>

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -1,8 +1,8 @@
-use super::super::DBMLib::lib;
-use super::component::Component;
+use crate::DBMLib::lib;
+use crate::ModelObjects::component::Component;
 use serde::Deserialize;
 
-///This file contains the nested enums used to represent systems on each side of refinement aswell as all guards, updates etc
+/// This file contains the nested enums used to represent systems on each side of refinement as well as all guards, updates etc
 /// note that the enum contains a box (pointer) to an object as they can only hold pointers to data on the heap
 
 #[derive(Debug, Clone, Deserialize, std::cmp::PartialEq)]
@@ -57,12 +57,12 @@ pub enum SystemRepresentation {
     Component(Component),
 }
 
-pub fn print_DBM(dbm: &mut [i32], dimension: &u32) {
+pub fn print_DBM(dbm: &mut [i32], dimension: u32) {
     println!("DBM:");
-    for i in 0..*dimension {
+    for i in 0..dimension {
         print!("( ");
-        for j in 0..*dimension {
-            print!("{:?} ", lib::rs_dbm_get_constraint(dbm, *dimension, i, j));
+        for j in 0..dimension {
+            print!("{:?} ", lib::rs_dbm_get_constraint(dbm, dimension, i, j));
         }
         print!(")\n");
     }

--- a/src/ModelObjects/system_declarations.rs
+++ b/src/ModelObjects/system_declarations.rs
@@ -42,7 +42,7 @@ impl SystemSpecification {
     }
 }
 
-//Function used for deserializing system declarations
+/// Function used for deserializing system declarations
 fn decode_sync_type<'de, D>(deserializer: D) -> Result<SystemSpecification, D::Error>
 where
     D: Deserializer<'de>,
@@ -119,14 +119,14 @@ where
                         }
                     }
                 } else {
-                    panic!("Was not able to finde component name: {:?} in declared component names: {:?}", component_name, component_names)
+                    panic!("Was not able to find component name: {:?} in declared component names: {:?}", component_name, component_names)
                 }
             }
         }
     }
     Ok(SystemSpecification {
-        components: components,
-        input_actions: input_actions,
-        output_actions: output_actions,
+        components,
+        input_actions,
+        output_actions,
     })
 }

--- a/src/ModelObjects/xml_parser.rs
+++ b/src/ModelObjects/xml_parser.rs
@@ -27,12 +27,11 @@ pub(crate) fn parse_xml(
     let mut xml_components: Vec<component::Component> = vec![];
 
     for xml_comp in root.find_all("template") {
-        let declarations: Declarations;
-        match xml_comp.find("declaration") {
-            Some(e) => declarations = parse_declarations(e.text()),
-            None => declarations = parse_declarations(""),
-        }
-        let edges: Vec<component::Edge> = collect_edges(xml_comp.find_all("transition"));
+        let declarations = match xml_comp.find("declaration") {
+            Some(e) => parse_declarations(e.text()),
+            None => parse_declarations(""),
+        };
+        let edges = collect_edges(xml_comp.find_all("transition"));
         // let input_edges: Vec<component::Edge> = edges.clone()
         //     .into_iter()
         //     .filter(|e| e.sync_type == SyncType::Input)
@@ -41,7 +40,7 @@ pub(crate) fn parse_xml(
         //     .into_iter()
         //     .filter(|e| e.sync_type == SyncType::Output)
         //     .collect();
-        let comp: component::Component = component::Component {
+        let comp = component::Component {
             name: xml_comp.find("name").unwrap().text().parse().unwrap(),
             declarations,
             locations: collect_locations(
@@ -59,7 +58,7 @@ pub(crate) fn parse_xml(
         xml_components.push(comp);
     }
 
-    let system_declarations: SystemDeclarations = SystemDeclarations {
+    let system_declarations = SystemDeclarations {
         name: "".to_string(),
         declarations: decode_sync_type(root.find("system").unwrap().text()),
     };
@@ -70,7 +69,7 @@ pub(crate) fn parse_xml(
 fn collect_locations(xml_locations: FindChildren, initial_id: &str) -> Vec<component::Location> {
     let mut locations: Vec<component::Location> = vec![];
     for loc in xml_locations {
-        let location: component::Location = component::Location {
+        let location = component::Location {
             id: loc.get_attr("id").unwrap().parse().unwrap(),
             invariant: match loc.find("label") {
                 Some(x) => match parse_invariant::parse(x.text()) {
@@ -120,7 +119,7 @@ fn collect_edges(xml_edges: FindChildren) -> Vec<Edge> {
                 _ => {}
             }
         }
-        let edge: component::Edge = component::Edge {
+        let edge = component::Edge {
             source_location: e
                 .find("source")
                 .expect("source edge not found")
@@ -186,7 +185,7 @@ fn parse_declarations(variables: &str) -> Declarations {
                 } else {
                     let mut error_string = "not implemented read for type: ".to_string();
                     error_string.push_str(&variable_type.to_string());
-                    panic!(error_string);
+                    panic!("{}", error_string);
                 }
             }
         }

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -1,11 +1,11 @@
-use super::super::ModelObjects::component;
-use super::super::ModelObjects::queries::Query;
-use super::super::ModelObjects::representations::QueryExpression;
-use super::super::ModelObjects::representations::SystemRepresentation;
+use crate::ModelObjects::component;
+use crate::ModelObjects::queries::Query;
+use crate::ModelObjects::representations::QueryExpression;
+use crate::ModelObjects::representations::SystemRepresentation;
 
-/// This function fetches the apropriate components based on the structure of the query and makes the enum structure match the query
-/// this function also handles setting up the correct indicies for clocks based on the amount of components in each system representation
-pub fn create_system_rep_from_query<'systemlifetime>(
+/// This function fetches the appropriate components based on the structure of the query and makes the enum structure match the query
+/// this function also handles setting up the correct indices for clocks based on the amount of components in each system representation
+pub fn create_system_rep_from_query<'system>(
     full_query: &Query,
     components: &Vec<component::Component>,
 ) -> (SystemRepresentation, Option<SystemRepresentation>, String) {
@@ -13,9 +13,9 @@ pub fn create_system_rep_from_query<'systemlifetime>(
 
     if let Some(query) = full_query.get_query() {
         match query {
-            QueryExpression::Refinement(leftside, rightside) => (
-                extract_side(leftside, components, &mut clock_index),
-                Some(extract_side(rightside, components, &mut clock_index)),
+            QueryExpression::Refinement(left_side, right_side) => (
+                extract_side(left_side, components, &mut clock_index),
+                Some(extract_side(right_side, components, &mut clock_index)),
                 String::from("refinement"),
             ),
             QueryExpression::Specification(body) => (
@@ -38,7 +38,7 @@ pub fn create_system_rep_from_query<'systemlifetime>(
                 None,
                 String::from("determinism"),
             ),
-            //Should handle consistency, Implementation, determinism and specificiation here, but we cant deal with it atm anyway
+            // Should handle consistency, Implementation, determinism and specification here, but we cant deal with it atm anyway
             _ => panic!("Not yet setup to handle {:?}", query),
         }
     } else {

--- a/src/System/input_enabler.rs
+++ b/src/System/input_enabler.rs
@@ -1,8 +1,8 @@
-use super::super::DBMLib::lib;
-use super::super::EdgeEval::constraint_applyer;
-use super::super::ModelObjects::component;
-use super::super::ModelObjects::representations;
-use super::super::ModelObjects::system_declarations;
+use crate::DBMLib::lib;
+use crate::EdgeEval::constraint_applyer;
+use crate::ModelObjects::component;
+use crate::ModelObjects::representations;
+use crate::ModelObjects::system_declarations;
 use std::collections::HashMap;
 use std::ptr;
 
@@ -23,7 +23,7 @@ pub fn make_input_enabled(
             let mut zone = [0; 1000];
             let mut state = component::State {
                 declarations: component.get_declarations().clone(),
-                location: location,
+                location,
             };
 
             lib::rs_dbm_zero(&mut zone[0..len as usize], dimension);
@@ -34,7 +34,7 @@ pub fn make_input_enabled(
                     invariant,
                     &mut state,
                     &mut zone[0..len as usize],
-                    &dimension,
+                    dimension,
                 );
             }
 
@@ -54,7 +54,7 @@ pub fn make_input_enabled(
                             guard,
                             &mut state,
                             &mut guard_zone[0..len as usize],
-                            &dimension,
+                            dimension,
                         );
                         res
                     } else {
@@ -83,7 +83,7 @@ pub fn make_input_enabled(
                                 target_invariant,
                                 &mut state,
                                 &mut guard_zone[0..len as usize],
-                                &dimension,
+                                dimension,
                             );
                         }
                         res
@@ -188,10 +188,10 @@ fn build_guard_from_zone(
     }
 
     let res = build_guard_from_zone_helper(&mut guards);
-    match res {
-        representations::BoolExpression::Bool(false) => return None,
-        _ => return Some(res),
-    }
+    return match res {
+        representations::BoolExpression::Bool(false) => None,
+        _ => Some(res),
+    };
 }
 
 fn build_guard_from_zone_helper(
@@ -199,18 +199,18 @@ fn build_guard_from_zone_helper(
 ) -> representations::BoolExpression {
     let num_guards = guards.len();
 
-    if let Some(guard) = guards.pop() {
+    return if let Some(guard) = guards.pop() {
         if num_guards == 1 {
-            return guard;
+            guard
         } else {
-            return representations::BoolExpression::AndOp(
+            representations::BoolExpression::AndOp(
                 Box::new(guard),
                 Box::new(build_guard_from_zone_helper(guards)),
-            );
+            )
         }
     } else {
-        return representations::BoolExpression::Bool(false);
-    }
+        representations::BoolExpression::Bool(false)
+    };
 }
 
 fn get_inv_clocks<'a>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn parse_automata(
     system_declarations::SystemDeclarations,
     Vec<queries::Query>,
 )> {
-    let mut paths: Vec<PathBuf> = vec![];
+    let mut paths: Vec<PathBuf>;
     match fs::read_dir(&folder_path) {
         Ok(read_value) => {
             paths = read_value

--- a/src/tests/dbm/dbm_basic.rs
+++ b/src/tests/dbm/dbm_basic.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use super::super::super::super::DBMLib::lib;
+    use crate::DBMLib::lib;
 
     #[test]
     fn testDbmValid0() {
@@ -157,18 +157,18 @@ mod test {
         lib::rs_dbm_add_LTE_constraint(dbm, 3, 1, 0, 4);
         let mut intArr2 = [1, 1, 1, 1, 1, 1, 1, 1, 1];
         let dbm2 = &mut intArr2;
-        lib::rs_dbm_init(dbm2, 3);
-        lib::rs_dbm_add_LTE_constraint(dbm2, 3, 2, 0, 4);
+        lib_linux::rs_dbm_init(dbm2, 3);
+        lib_linux::rs_dbm_add_LTE_constraint(dbm2, 3, 2, 0, 4);
         //assert_eq!([1, -3, 11, 1].as_mut(), dbm);
         assert_eq!([1, -3, 11, 1].as_mut(), dbm2);
     }
 
     #[test]
     fn testDbmReset1() {
-        //TODO Check why it fails whilel it shouldn't
+        //TODO Check why it fails while it shouldn't
         let mut intArr = [1, -3, 11, 1];
         let dbm = &mut intArr;
-        lib::rs_dbm_constrain_var_to_val(dbm, 2, 1, 0);
+        lib_linux::rs_dbm_constrain_var_to_val(dbm, 2, 1, 0);
         assert_eq!([1, 1, 1, 1].as_mut(), dbm);
     }
 
@@ -176,7 +176,7 @@ mod test {
     fn testDbmReset2() {
         let mut intArr = [1, 1, 1, 7, 1, 7, 5, 5, 1];
         let dbm = &mut intArr;
-        lib::rs_dbm_constrain_var_to_val(dbm, 3, 1, 0);
+        lib_linux::rs_dbm_constrain_var_to_val(dbm, 3, 1, 0);
         assert_eq!([1, 1, 1, 1, 1, 1, 5, 5, 1].as_mut(), dbm);
     }
 
@@ -184,16 +184,16 @@ mod test {
     fn testDbmFuture1() {
         let mut intArr = [1, 1, 1, 1];
         let dbm = &mut intArr;
-        lib::rs_dbm_up(dbm, 2);
-        assert_eq!([1, 1, lib::DBM_INF, 1].as_mut(), dbm);
+        lib_linux::rs_dbm_up(dbm, 2);
+        assert_eq!([1, 1, lib_linux::DBM_INF, 1].as_mut(), dbm);
     }
 
     #[test]
     fn testDbmFuture2() {
         let mut intArr = [1, -3, 11, 1];
         let dbm = &mut intArr;
-        lib::rs_dbm_up(dbm, 2);
-        assert_eq!([1, -3, lib::DBM_INF, 1].as_mut(), dbm);
+        lib_linux::rs_dbm_up(dbm, 2);
+        assert_eq!([1, -3, lib_linux::DBM_INF, 1].as_mut(), dbm);
     }
 
     #[test]
@@ -204,11 +204,11 @@ mod test {
             1,
             1,
             1,
-            lib::DBM_INF,
+            lib_linux::DBM_INF,
             1,
-            lib::DBM_INF,
-            lib::DBM_INF,
-            lib::DBM_INF,
+            lib_linux::DBM_INF,
+            lib_linux::DBM_INF,
+            lib_linux::DBM_INF,
             1,
         ];
         let _dbm1 = &mut intArr1;
@@ -216,20 +216,20 @@ mod test {
             1,
             1,
             1,
-            lib::DBM_INF,
+            lib_linux::DBM_INF,
             1,
-            lib::DBM_INF,
-            lib::DBM_INF,
-            lib::DBM_INF,
+            lib_linux::DBM_INF,
+            lib_linux::DBM_INF,
+            lib_linux::DBM_INF,
             1,
         ];
         let dbm2 = &mut intArr2;
 
-        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 1, -2);
+        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 1, -2);
         println!("{:?}", dbm2);
-        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 2, -3);
-        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 1, 0, 4);
-        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 2, 0, 5);
+        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 2, -3);
+        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 1, 0, 4);
+        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 2, 0, 5);
         println!("{:?}", dbm2);
         //TODO check DBM - DBM error
         //let mut arr1 = lib::rs_dbm_minus_dbm(dbm1, dbm2, dim);

--- a/src/tests/dbm/dbm_basic.rs
+++ b/src/tests/dbm/dbm_basic.rs
@@ -157,8 +157,8 @@ mod test {
         lib::rs_dbm_add_LTE_constraint(dbm, 3, 1, 0, 4);
         let mut intArr2 = [1, 1, 1, 1, 1, 1, 1, 1, 1];
         let dbm2 = &mut intArr2;
-        lib_linux::rs_dbm_init(dbm2, 3);
-        lib_linux::rs_dbm_add_LTE_constraint(dbm2, 3, 2, 0, 4);
+        lib::rs_dbm_init(dbm2, 3);
+        lib::rs_dbm_add_LTE_constraint(dbm2, 3, 2, 0, 4);
         //assert_eq!([1, -3, 11, 1].as_mut(), dbm);
         assert_eq!([1, -3, 11, 1].as_mut(), dbm2);
     }
@@ -168,7 +168,7 @@ mod test {
         //TODO Check why it fails while it shouldn't
         let mut intArr = [1, -3, 11, 1];
         let dbm = &mut intArr;
-        lib_linux::rs_dbm_constrain_var_to_val(dbm, 2, 1, 0);
+        lib::rs_dbm_constrain_var_to_val(dbm, 2, 1, 0);
         assert_eq!([1, 1, 1, 1].as_mut(), dbm);
     }
 
@@ -176,7 +176,7 @@ mod test {
     fn testDbmReset2() {
         let mut intArr = [1, 1, 1, 7, 1, 7, 5, 5, 1];
         let dbm = &mut intArr;
-        lib_linux::rs_dbm_constrain_var_to_val(dbm, 3, 1, 0);
+        lib::rs_dbm_constrain_var_to_val(dbm, 3, 1, 0);
         assert_eq!([1, 1, 1, 1, 1, 1, 5, 5, 1].as_mut(), dbm);
     }
 
@@ -184,16 +184,16 @@ mod test {
     fn testDbmFuture1() {
         let mut intArr = [1, 1, 1, 1];
         let dbm = &mut intArr;
-        lib_linux::rs_dbm_up(dbm, 2);
-        assert_eq!([1, 1, lib_linux::DBM_INF, 1].as_mut(), dbm);
+        lib::rs_dbm_up(dbm, 2);
+        assert_eq!([1, 1, lib::DBM_INF, 1].as_mut(), dbm);
     }
 
     #[test]
     fn testDbmFuture2() {
         let mut intArr = [1, -3, 11, 1];
         let dbm = &mut intArr;
-        lib_linux::rs_dbm_up(dbm, 2);
-        assert_eq!([1, -3, lib_linux::DBM_INF, 1].as_mut(), dbm);
+        lib::rs_dbm_up(dbm, 2);
+        assert_eq!([1, -3, lib::DBM_INF, 1].as_mut(), dbm);
     }
 
     #[test]
@@ -204,11 +204,11 @@ mod test {
             1,
             1,
             1,
-            lib_linux::DBM_INF,
+            lib::DBM_INF,
             1,
-            lib_linux::DBM_INF,
-            lib_linux::DBM_INF,
-            lib_linux::DBM_INF,
+            lib::DBM_INF,
+            lib::DBM_INF,
+            lib::DBM_INF,
             1,
         ];
         let _dbm1 = &mut intArr1;
@@ -216,20 +216,20 @@ mod test {
             1,
             1,
             1,
-            lib_linux::DBM_INF,
+            lib::DBM_INF,
             1,
-            lib_linux::DBM_INF,
-            lib_linux::DBM_INF,
-            lib_linux::DBM_INF,
+            lib::DBM_INF,
+            lib::DBM_INF,
+            lib::DBM_INF,
             1,
         ];
         let dbm2 = &mut intArr2;
 
-        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 1, -2);
+        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 1, -2);
         println!("{:?}", dbm2);
-        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 2, -3);
-        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 1, 0, 4);
-        lib_linux::rs_dbm_add_LTE_constraint(dbm2, dim, 2, 0, 5);
+        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 0, 2, -3);
+        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 1, 0, 4);
+        lib::rs_dbm_add_LTE_constraint(dbm2, dim, 2, 0, 5);
         println!("{:?}", dbm2);
         //TODO check DBM - DBM error
         //let mut arr1 = lib::rs_dbm_minus_dbm(dbm1, dbm2, dim);

--- a/src/tests/refinement/Conjunction_refinement.rs
+++ b/src/tests/refinement/Conjunction_refinement.rs
@@ -160,7 +160,7 @@ mod Conjunction_refinement {
     #[test]
     fn test1NestedConjRefinesT5() {
         let (automataList, decl) = setup(PATH.to_string());
-        let ts1: SystemRepresentation = SystemRepresentation::Conjunction(
+        let ts1 = SystemRepresentation::Conjunction(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),
@@ -204,7 +204,7 @@ mod Conjunction_refinement {
     #[test]
     fn test1NestedConjRefinesT12() {
         let (automataList, decl) = setup(PATH.to_string());
-        let ts1: SystemRepresentation = SystemRepresentation::Conjunction(
+        let ts1 = SystemRepresentation::Conjunction(
             Box::from(SystemRepresentation::Component(
                 automataList.get(8).unwrap().clone(),
             )),

--- a/src/tests/refinement/Refinement_delay_add.rs
+++ b/src/tests/refinement/Refinement_delay_add.rs
@@ -10,7 +10,7 @@ mod Refinement_delay_add {
     #[test]
     fn A1A2NotRefinesB() {
         let (automataList, decl) = setup(PATH.to_string());
-        let comp: SystemRepresentation = SystemRepresentation::Composition(
+        let comp = SystemRepresentation::Composition(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),

--- a/src/tests/refinement/Refinement_university.rs
+++ b/src/tests/refinement/Refinement_university.rs
@@ -322,9 +322,9 @@ mod Refinement_university {
 
     #[test]
     fn testCompRefinesSpec() {
-        //TODO This test must succeed, while it fails
+        // TODO This test must succeed, while it fails
         let (automataList, decl) = setup(PATH.to_string());
-        let comp: SystemRepresentation = SystemRepresentation::Composition(
+        let comp = SystemRepresentation::Composition(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),
@@ -347,9 +347,9 @@ mod Refinement_university {
 
     #[test]
     fn testCompRefinesSelf() {
-        //TODO This test must succeed, while it fails
+        // TODO This test must succeed, while it fails
         let (automataList, decl) = setup(PATH.to_string());
-        let comp1: SystemRepresentation = SystemRepresentation::Composition(
+        let comp1 = SystemRepresentation::Composition(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),
@@ -357,13 +357,13 @@ mod Refinement_university {
                 automataList.get(1).unwrap().clone(),
             )),
         );
-        let comp2: SystemRepresentation = SystemRepresentation::Conjunction(
+        let comp2 = SystemRepresentation::Conjunction(
             Box::from(comp1),
             Box::from(SystemRepresentation::Component(
                 automataList.get(2).unwrap().clone(),
             )),
         );
-        let compCopy1: SystemRepresentation = SystemRepresentation::Composition(
+        let compCopy1 = SystemRepresentation::Composition(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),
@@ -371,7 +371,7 @@ mod Refinement_university {
                 automataList.get(1).unwrap().clone(),
             )),
         );
-        let compCopy2: SystemRepresentation = SystemRepresentation::Conjunction(
+        let compCopy2 = SystemRepresentation::Conjunction(
             Box::from(compCopy1),
             Box::from(SystemRepresentation::Component(
                 automataList.get(2).unwrap().clone(),
@@ -382,9 +382,9 @@ mod Refinement_university {
 
     #[test]
     fn testHalf1AndHalf2RefinesAdm2() {
-        //TODO This test must succeed, while it fails
+        // TODO This test must succeed, while it fails
         let (automataList, decl) = setup(PATH.to_string());
-        let conj: SystemRepresentation = SystemRepresentation::Conjunction(
+        let conj = SystemRepresentation::Conjunction(
             Box::from(SystemRepresentation::Component(
                 automataList.get(6).unwrap().clone(),
             )),
@@ -402,9 +402,9 @@ mod Refinement_university {
 
     #[test]
     fn testAdm2RefinesHalf1AndHalf2() {
-        //TODO This test must succeed, while it fails
+        // TODO This test must succeed, while it fails
         let (automataList, decl) = setup(PATH.to_string());
-        let conj: SystemRepresentation = SystemRepresentation::Conjunction(
+        let conj = SystemRepresentation::Conjunction(
             Box::from(SystemRepresentation::Component(
                 automataList.get(6).unwrap().clone(),
             )),

--- a/src/tests/refinement/Refinement_unspec.rs
+++ b/src/tests/refinement/Refinement_unspec.rs
@@ -44,7 +44,7 @@ mod Refinement_unspec {
     fn compNotRefinesB() {
         // should fail because right side has more inputs
         let (automataList, decl) = setup(PATH.to_string());
-        let comp: SystemRepresentation = SystemRepresentation::Composition(
+        let comp = SystemRepresentation::Composition(
             Box::from(SystemRepresentation::Component(
                 automataList.get(0).unwrap().clone(),
             )),

--- a/src/tests/refinement/xml/determinism_tests.rs
+++ b/src/tests/refinement/xml/determinism_tests.rs
@@ -368,7 +368,7 @@ mod determinism_tests {
 
     #[test]
     fn testG23() {
-        //shouldn't be deterministic
+        // shouldn't be deterministic
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);
         let optimized_components = optimize_components(automataList, &decl);
         let query = parse_queries::parse("determinism: G23").unwrap();


### PR DESCRIPTION
Changed &u32 into just a u32 for performance. The pointer will either be the same size or large so instead just pass the value.
Added whitespace between functions and fields.
Fixed several spelling mistakes.
Fixed misuse of panic! macro. The first argument should be a format string, not the value to be printed.
Converted comments on top of functions into documentation.
Removed types from variables where they can be inferred.
Change 'use super::' to 'use crate::' for a more idiomatic import.
Make a lot of code more idiomatic.