### PR TITLE
Moved refinement preconditions

### DIFF
--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -25,11 +25,7 @@ pub fn check_refinement(
     let mut combined_transitions1: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
     let mut combined_transitions2: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
 
-    if !check_preconditions(&mut sys1, &mut sys2, &outputs1, &inputs2, sys_decls) {
-        println!("preconditions failed - refinement false");
-        return Ok(false);
-    }
-
+    
     get_actions(&sys2, sys_decls, true, &mut inputs2, &mut initial_states_2);
     get_actions(
         &sys1,
@@ -38,7 +34,11 @@ pub fn check_refinement(
         &mut outputs1,
         &mut initial_states_1,
     );
-
+    
+    if !check_preconditions(&mut sys1.clone(), &mut sys2.clone(), &outputs1, &inputs2, sys_decls) {
+        println!("preconditions failed - refinement false");
+        return Ok(false);
+    }
     //Firstly we check the preconditions
 
     let mut initial_pair = create_state_pair(initial_states_1.clone(), initial_states_2.clone());

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -25,7 +25,6 @@ pub fn check_refinement(
     let mut combined_transitions1: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
     let mut combined_transitions2: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
 
-    
     get_actions(&sys2, sys_decls, true, &mut inputs2, &mut initial_states_2);
     get_actions(
         &sys1,
@@ -35,11 +34,11 @@ pub fn check_refinement(
         &mut initial_states_1,
     );
     
+    //Firstly we check the preconditions
     if !check_preconditions(&mut sys1.clone(), &mut sys2.clone(), &outputs1, &inputs2, sys_decls) {
         println!("preconditions failed - refinement false");
         return Ok(false);
     }
-    //Firstly we check the preconditions
 
     let mut initial_pair = create_state_pair(initial_states_1.clone(), initial_states_2.clone());
     initial_pair.init_dbm();

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -42,7 +42,13 @@ pub fn check_refinement(
     );
 
     //Firstly we check the preconditions
-    if !check_preconditions(&mut sys1.clone(), &mut sys2.clone(), &outputs1, &inputs2, sys_decls) {
+    if !check_preconditions(
+        &mut sys1.clone(),
+        &mut sys2.clone(),
+        &outputs1,
+        &inputs2,
+        sys_decls,
+    ) {
         println!("preconditions failed - refinement false");
         return Ok(false);
     }

--- a/src/tests/refinement/xml/delay_refinement.rs
+++ b/src/tests/refinement/xml/delay_refinement.rs
@@ -47,7 +47,7 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
-    #[ignore]
+    
     #[test]
     fn T2RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);
@@ -286,7 +286,6 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
-    #[ignore]
     #[test]
     fn T10RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);
@@ -814,7 +813,6 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
-    #[ignore]
     #[test]
     fn Z3RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);

--- a/src/tests/refinement/xml/delay_refinement.rs
+++ b/src/tests/refinement/xml/delay_refinement.rs
@@ -47,7 +47,6 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
-    
     #[test]
     fn T2RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);


### PR DESCRIPTION
Currently `check_preconditions` gets called before its parameters are populated.

This PR simply moves the check down after `inputs2` and `outputs1` are populated, fixing the tests:
tests::refinement::Refinement_delay_add::Refinement_delay_add::D1NotRefinesD2, tests::refinement::Refinement_unspec::Refinement_unspec::compNotRefinesB

But this comes at the cost of having to clone `sys1` and `sys2` as the `get_actions` calls borrows these variables, so we cant make a mutable reference.