### PR TITLE
Refactoring refinement

### DIFF
--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -774,6 +774,22 @@ impl Edge {
         }
     }
 
+    pub fn apply_guard(
+        &self,
+        state: &State,
+        zone: &mut [i32],
+        dim: u32
+    ) -> bool {
+        return if let Some(guards) = self.get_guard() {
+            let success =
+                apply_constraints_to_state(guards, state, zone, dim);
+            success
+        } else {
+            true
+        }
+        
+    }
+
     pub fn get_source_location(&self) -> &String {
         &self.source_location
     }

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -802,68 +802,6 @@ impl Channel {
     }
 }
 
-#[derive(Clone)]
-pub struct StatePair<'a> {
-    pub states1: Vec<State<'a>>,
-    pub states2: Vec<State<'a>>,
-    pub zone: [i32; 1000],
-    pub dimensions: u32,
-}
-
-impl<'b> StatePair<'b> {
-    pub fn get_states1(&self) -> &Vec<State> {
-        &self.states1
-    }
-
-    pub fn get_states2(&self) -> &Vec<State> {
-        &self.states2
-    }
-
-    pub fn get_mut_states1(&mut self) -> &mut Vec<State<'b>> {
-        &mut self.states1
-    }
-
-    pub fn get_mut_states2(&mut self) -> &mut Vec<State<'b>> {
-        &mut self.states2
-    }
-
-    pub fn get_dimensions(&self) -> u32 {
-        self.dimensions.clone()
-    }
-
-    pub fn set_dimensions(&mut self, dim: u32) {
-        self.dimensions = dim;
-    }
-
-    pub fn get_zone(&mut self) -> &mut [i32] {
-        let dim = self.get_dimensions();
-        let len = dim * dim;
-        &mut self.zone[0..len as usize]
-    }
-
-    pub fn get_dbm_clone(&self) -> [i32; 1000] {
-        return self.zone.clone();
-    }
-
-    pub fn set_dbm(&mut self, dbm: [i32; 1000]) {
-        self.zone = dbm;
-    }
-
-    pub fn init_dbm(&mut self) {
-        let mut dimensions = 1;
-        for state in self.get_states1() {
-            dimensions += state.get_dimensions();
-        }
-
-        for state in self.get_states2() {
-            dimensions += state.get_dimensions();
-        }
-        self.dimensions = dimensions;
-        lib::rs_dbm_zero(self.get_zone(), dimensions);
-        lib::rs_dbm_up(self.get_zone(), dimensions);
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct State<'a> {
     pub location: &'a Location,

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -8,6 +8,7 @@ use crate::ModelObjects::representations;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 
 /// The basic struct used to represent components read from either Json or xml
 #[derive(Debug, Deserialize, Clone)]
@@ -810,6 +811,21 @@ pub struct State<'a> {
 
 #[allow(dead_code)]
 impl<'a> State<'a> {
+    pub fn apply_invariant(
+        &self,
+        zone: &mut [i32],
+        dim: u32,
+    ) -> bool {
+        if let Some(inv) = self
+            .get_location()
+            .get_invariant()
+        {
+            apply_constraints_to_state(&inv, self, zone, dim)
+        } else {
+            true
+        }
+    }
+
     pub fn get_declarations(&self) -> &Declarations {
         &self.declarations
     }

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -827,6 +827,13 @@ pub struct State<'a> {
 
 #[allow(dead_code)]
 impl<'a> State<'a> {
+    pub fn create(location: &Location, declarations: Declarations) -> State {
+        return State {
+            location,
+            declarations,
+        };
+    }
+
     pub fn apply_invariant(&self, zone: &mut [i32], dim: u32) -> bool {
         if let Some(inv) = self.get_location().get_invariant() {
             apply_constraints_to_state(&inv, self, zone, dim)

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -1,6 +1,8 @@
 use crate::DBMLib::lib;
 use crate::EdgeEval::constraint_applyer;
+use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 use crate::EdgeEval::updater::fullState_updater;
+use crate::EdgeEval::updater::updater;
 use crate::ModelObjects;
 use crate::ModelObjects::parse_edge;
 use crate::ModelObjects::parse_invariant;
@@ -8,8 +10,6 @@ use crate::ModelObjects::representations;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
-use crate::EdgeEval::updater::updater;
 
 /// The basic struct used to represent components read from either Json or xml
 #[derive(Debug, Deserialize, Clone)]
@@ -758,36 +758,19 @@ pub struct Edge {
 }
 
 impl Edge {
-    pub fn apply_update(
-        &self,
-        state: &mut State,
-        zone: &mut [i32],
-        dim: u32,
-    ) {
+    pub fn apply_update(&self, state: &mut State, zone: &mut [i32], dim: u32) {
         if let Some(updates) = self.get_update() {
-            updater(
-                updates,
-                state,
-                zone,
-                dim,
-            );
+            updater(updates, state, zone, dim);
         }
     }
 
-    pub fn apply_guard(
-        &self,
-        state: &State,
-        zone: &mut [i32],
-        dim: u32
-    ) -> bool {
+    pub fn apply_guard(&self, state: &State, zone: &mut [i32], dim: u32) -> bool {
         return if let Some(guards) = self.get_guard() {
-            let success =
-                apply_constraints_to_state(guards, state, zone, dim);
+            let success = apply_constraints_to_state(guards, state, zone, dim);
             success
         } else {
             true
-        }
-        
+        };
     }
 
     pub fn get_source_location(&self) -> &String {
@@ -844,15 +827,8 @@ pub struct State<'a> {
 
 #[allow(dead_code)]
 impl<'a> State<'a> {
-    pub fn apply_invariant(
-        &self,
-        zone: &mut [i32],
-        dim: u32,
-    ) -> bool {
-        if let Some(inv) = self
-            .get_location()
-            .get_invariant()
-        {
+    pub fn apply_invariant(&self, zone: &mut [i32], dim: u32) -> bool {
+        if let Some(inv) = self.get_location().get_invariant() {
             apply_constraints_to_state(&inv, self, zone, dim)
         } else {
             true

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -766,8 +766,7 @@ impl Edge {
 
     pub fn apply_guard(&self, state: &State, zone: &mut [i32], dim: u32) -> bool {
         return if let Some(guards) = self.get_guard() {
-            let success = apply_constraints_to_state(guards, state, zone, dim);
-            success
+            apply_constraints_to_state(guards, state, zone, dim)
         } else {
             true
         };
@@ -828,10 +827,10 @@ pub struct State<'a> {
 #[allow(dead_code)]
 impl<'a> State<'a> {
     pub fn create(location: &Location, declarations: Declarations) -> State {
-        return State {
+        State {
             location,
             declarations,
-        };
+        }
     }
 
     pub fn apply_invariant(&self, zone: &mut [i32], dim: u32) -> bool {

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
+use crate::EdgeEval::updater::updater;
 
 /// The basic struct used to represent components read from either Json or xml
 #[derive(Debug, Deserialize, Clone)]
@@ -757,6 +758,22 @@ pub struct Edge {
 }
 
 impl Edge {
+    pub fn apply_update(
+        &self,
+        state: &mut State,
+        zone: &mut [i32],
+        dim: u32,
+    ) {
+        if let Some(updates) = self.get_update() {
+            updater(
+                updates,
+                state,
+                zone,
+                dim,
+            );
+        }
+    }
+
     pub fn get_source_location(&self) -> &String {
         &self.source_location
     }

--- a/src/ModelObjects/mod.rs
+++ b/src/ModelObjects/mod.rs
@@ -4,6 +4,6 @@ pub mod parse_invariant;
 pub mod parse_queries;
 pub mod queries;
 pub mod representations;
+pub mod statepair;
 pub mod system_declarations;
 pub mod xml_parser;
-pub mod statepair;

--- a/src/ModelObjects/mod.rs
+++ b/src/ModelObjects/mod.rs
@@ -6,3 +6,4 @@ pub mod queries;
 pub mod representations;
 pub mod system_declarations;
 pub mod xml_parser;
+pub mod statepair;

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -57,25 +57,20 @@ pub enum SystemRepresentation {
     Component(Component),
 }
 
-impl<'a> SystemRepresentation{
-    pub fn any_composition<F>(
-        &'a self,
-        predicate: &mut F
-    ) -> bool where
-    F: FnMut(&'a Component) -> bool{
-        match self{
+impl<'a> SystemRepresentation {
+    pub fn any_composition<F>(&'a self, predicate: &mut F) -> bool
+    where
+        F: FnMut(&'a Component) -> bool,
+    {
+        match self {
             SystemRepresentation::Composition(left_side, right_side) => {
                 left_side.any_composition(predicate) || right_side.any_composition(predicate)
             }
             SystemRepresentation::Conjunction(left_side, right_side) => {
                 left_side.any_composition(predicate) && right_side.any_composition(predicate)
             }
-            SystemRepresentation::Parentheses(rep) => {
-                rep.any_composition(predicate)
-            }
-            SystemRepresentation::Component(comp) => {
-                predicate(comp)
-            }
+            SystemRepresentation::Parentheses(rep) => rep.any_composition(predicate),
+            SystemRepresentation::Component(comp) => predicate(comp),
         }
     }
 }

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -73,6 +73,22 @@ impl<'a> SystemRepresentation {
             SystemRepresentation::Component(comp) => predicate(comp),
         }
     }
+
+    pub fn all_components<F>(&'a mut self, predicate: &mut F) -> bool
+    where
+        F: FnMut(&'a mut Component) -> bool,
+    {
+        match self {
+            SystemRepresentation::Composition(left_side, right_side) => {
+                left_side.all_components(predicate) && right_side.all_components(predicate)
+            }
+            SystemRepresentation::Conjunction(left_side, right_side) => {
+                left_side.all_components(predicate) && right_side.all_components(predicate)
+            }
+            SystemRepresentation::Parentheses(rep) => rep.all_components(predicate),
+            SystemRepresentation::Component(comp) => predicate(comp),
+        }
+    }
 }
 
 pub fn print_DBM(dbm: &mut [i32], dimension: u32) {

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -109,41 +109,39 @@ impl<'a> SystemRepresentation {
 
     pub fn collect_open_inputs(
         &'a self,
-        states: &Vec<State<'a>>,
-        action: &String,
+        states: &[State<'a>],
+        action: &str,
     ) -> Result<Vec<(&'a Component, Vec<&'a Edge>, usize)>, String> {
         let mut edges = vec![];
         let mut index = 0;
 
-        return if self.collect_open_edges(states, &mut index, action, &mut edges, &SyncType::Input)
-        {
+        if self.collect_open_edges(states, &mut index, action, &mut edges, &SyncType::Input) {
             Ok(edges)
         } else {
             Err("Conjunction rules on output not satisfied".to_string())
-        };
+        }
     }
 
     pub fn collect_open_outputs(
         &'a self,
-        states: &Vec<State<'a>>,
-        action: &String,
+        states: &[State<'a>],
+        action: &str,
     ) -> Result<Vec<(&'a Component, Vec<&'a Edge>, usize)>, String> {
         let mut edges = vec![];
         let mut index = 0;
 
-        return if self.collect_open_edges(states, &mut index, action, &mut edges, &SyncType::Output)
-        {
+        if self.collect_open_edges(states, &mut index, action, &mut edges, &SyncType::Output) {
             Ok(edges)
         } else {
             Err("Conjunction rules on input not satisfied".to_string())
-        };
+        }
     }
 
     fn collect_open_edges(
         &'a self,
-        states: &Vec<State<'a>>,
+        states: &[State<'a>],
         index: &mut usize,
-        action: &String,
+        action: &str,
         open_edges: &mut Vec<(&'a Component, Vec<&'a Edge>, usize)>,
         sync_type: &SyncType,
     ) -> bool {
@@ -161,7 +159,7 @@ impl<'a> SystemRepresentation {
                         return left_found_transitions == right_found_transitions;
                     }
                 }
-                return false;
+                false
             }
             SystemRepresentation::Parentheses(rep) => {
                 rep.collect_open_edges(states, index, action, open_edges, sync_type)
@@ -170,7 +168,7 @@ impl<'a> SystemRepresentation {
                 let next_edges =
                     comp.get_next_edges(states[*index].get_location(), action, *sync_type);
 
-                if next_edges.len() > 0 {
+                if !next_edges.is_empty() {
                     open_edges.push((comp, next_edges, *index));
                 }
 
@@ -213,7 +211,7 @@ impl<'a> SystemRepresentation {
             true
         });
 
-        return actions;
+        actions
     }
 
     pub fn get_initial_states(&'a self) -> Vec<State<'a>> {
@@ -221,7 +219,7 @@ impl<'a> SystemRepresentation {
         self.all_components(&mut |comp: &Component| -> bool {
             let init_loc = comp
                 .get_locations()
-                .into_iter()
+                .iter()
                 .find(|location| location.get_location_type() == &LocationType::Initial);
             if let Some(init_loc) = init_loc {
                 let state = State::create(init_loc, comp.get_declarations().clone());
@@ -242,6 +240,6 @@ pub fn print_DBM(dbm: &mut [i32], dimension: u32) {
         for j in 0..dimension {
             print!("{:?} ", lib::rs_dbm_get_constraint(dbm, dimension, i, j));
         }
-        print!(")\n");
+        println!(")");
     }
 }

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -214,6 +214,52 @@ impl<'a> SystemRepresentation {
         actions
     }
 
+    pub fn find_matching_input(
+        &self,
+        sys_decls: &SystemDeclarations,
+        inputs2: &[String],
+    ) -> Vec<String> {
+        let inputs1 = self.get_input_actions(&sys_decls);
+
+        let mut matching_i: Vec<String> = vec![];
+        for i2 in inputs2 {
+            let mut found_match = false;
+            for i1 in &inputs1 {
+                if i1 == i2 {
+                    found_match = true;
+                }
+            }
+            if !found_match {
+                matching_i.push(i2.clone());
+            }
+        }
+
+        matching_i
+    }
+
+    pub fn find_matching_output(
+        &self,
+        sys_decls: &SystemDeclarations,
+        outputs1: &[String],
+    ) -> Vec<String> {
+        let outputs2 = self.get_output_actions(&sys_decls);
+
+        let mut matching_o: Vec<String> = vec![];
+        for o1 in outputs1 {
+            let mut found_match = false;
+            for o2 in &outputs2 {
+                if o1 == o2 {
+                    found_match = true;
+                }
+            }
+            if !found_match {
+                matching_o.push(o1.clone());
+            }
+        }
+
+        matching_o
+    }
+
     pub fn get_initial_states(&'a self) -> Vec<State<'a>> {
         let mut states = vec![];
         self.all_components(&mut |comp: &Component| -> bool {
@@ -230,6 +276,21 @@ impl<'a> SystemRepresentation {
         });
 
         states
+    }
+
+    pub fn precheck_sys_rep(&mut self) -> bool {
+        self.all_mut_components(&mut |comp: &mut Component| -> bool {
+            let clock_clone = comp.get_declarations().get_clocks().clone();
+
+            let len = comp.get_mut_declaration().get_clocks().len();
+            comp.get_mut_declaration().dimension = 1 + len as u32;
+
+            comp.get_mut_declaration().reset_clock_indices();
+
+            let res = comp.check_consistency(true);
+            comp.get_mut_declaration().clocks = clock_clone;
+            res
+        })
     }
 }
 

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -57,6 +57,29 @@ pub enum SystemRepresentation {
     Component(Component),
 }
 
+impl<'a> SystemRepresentation{
+    pub fn any_composition<F>(
+        &'a self,
+        predicate: &mut F
+    ) -> bool where
+    F: FnMut(&'a Component) -> bool{
+        match self{
+            SystemRepresentation::Composition(left_side, right_side) => {
+                left_side.any_composition(predicate) || right_side.any_composition(predicate)
+            }
+            SystemRepresentation::Conjunction(left_side, right_side) => {
+                left_side.any_composition(predicate) && right_side.any_composition(predicate)
+            }
+            SystemRepresentation::Parentheses(rep) => {
+                rep.any_composition(predicate)
+            }
+            SystemRepresentation::Component(comp) => {
+                predicate(comp)
+            }
+        }
+    }
+}
+
 pub fn print_DBM(dbm: &mut [i32], dimension: u32) {
     println!("DBM:");
     for i in 0..dimension {

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -27,14 +27,6 @@ impl<'b> StatePair<'b> {
         &self.states2
     }
 
-    pub fn get_mut_states1(&mut self) -> &mut Vec<State<'b>> {
-        &mut self.states1
-    }
-
-    pub fn get_mut_states2(&mut self) -> &mut Vec<State<'b>> {
-        &mut self.states2
-    }
-
     //Used to allow borrowing both states as mutable
     pub fn get_mut_states(
         &mut self,

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -1,0 +1,73 @@
+use crate::ModelObjects::component::State;
+use crate::DBMLib::lib;
+
+#[derive(Clone)]
+pub struct StatePair<'a> {
+    pub states1: Vec<State<'a>>,
+    pub states2: Vec<State<'a>>,
+    pub zone: [i32; 1000],
+    pub dimensions: u32,
+}
+
+impl<'b> StatePair<'b> {
+    pub fn create<'a>(state1: Vec<State<'a>>, state2: Vec<State<'a>>) -> StatePair<'a> {
+        return StatePair {
+            states1: state1,
+            states2: state2,
+            zone: [0; 1000],
+            dimensions: 0,
+        };
+    }
+
+    pub fn get_states1(&self) -> &Vec<State> {
+        &self.states1
+    }
+
+    pub fn get_states2(&self) -> &Vec<State> {
+        &self.states2
+    }
+
+    pub fn get_mut_states1(&mut self) -> &mut Vec<State<'b>> {
+        &mut self.states1
+    }
+
+    pub fn get_mut_states2(&mut self) -> &mut Vec<State<'b>> {
+        &mut self.states2
+    }
+
+    pub fn get_dimensions(&self) -> u32 {
+        self.dimensions.clone()
+    }
+
+    pub fn set_dimensions(&mut self, dim: u32) {
+        self.dimensions = dim;
+    }
+
+    pub fn get_zone(&mut self) -> &mut [i32] {
+        let dim = self.get_dimensions();
+        let len = dim * dim;
+        &mut self.zone[0..len as usize]
+    }
+
+    pub fn get_dbm_clone(&self) -> [i32; 1000] {
+        return self.zone.clone();
+    }
+
+    pub fn set_dbm(&mut self, dbm: [i32; 1000]) {
+        self.zone = dbm;
+    }
+
+    pub fn init_dbm(&mut self) {
+        let mut dimensions = 1;
+        for state in self.get_states1() {
+            dimensions += state.get_dimensions();
+        }
+
+        for state in self.get_states2() {
+            dimensions += state.get_dimensions();
+        }
+        self.dimensions = dimensions;
+        lib::rs_dbm_zero(self.get_zone(), dimensions);
+        lib::rs_dbm_up(self.get_zone(), dimensions);
+    }
+}

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -1,5 +1,5 @@
-use crate::ModelObjects::component::State;
 use crate::DBMLib::lib;
+use crate::ModelObjects::component::State;
 
 #[derive(Clone)]
 pub struct StatePair<'a> {

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -11,12 +11,12 @@ pub struct StatePair<'a> {
 
 impl<'b> StatePair<'b> {
     pub fn create<'a>(state1: Vec<State<'a>>, state2: Vec<State<'a>>) -> StatePair<'a> {
-        return StatePair {
+        StatePair {
             states1: state1,
             states2: state2,
             zone: [0; 1000],
             dimensions: 0,
-        };
+        }
     }
 
     pub fn get_states1(&self) -> &Vec<State<'b>> {
@@ -32,15 +32,15 @@ impl<'b> StatePair<'b> {
         &mut self,
         is_states1: bool,
     ) -> (&mut Vec<State<'b>>, &mut Vec<State<'b>>) {
-        return if is_states1 {
+        if is_states1 {
             (&mut self.states1, &mut self.states2)
         } else {
             (&mut self.states2, &mut self.states1)
-        };
+        }
     }
 
     pub fn get_dimensions(&self) -> u32 {
-        self.dimensions.clone()
+        self.dimensions
     }
 
     pub fn set_dimensions(&mut self, dim: u32) {
@@ -54,7 +54,7 @@ impl<'b> StatePair<'b> {
     }
 
     pub fn get_dbm_clone(&self) -> [i32; 1000] {
-        return self.zone.clone();
+        self.zone
     }
 
     pub fn set_dbm(&mut self, dbm: [i32; 1000]) {

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -19,11 +19,11 @@ impl<'b> StatePair<'b> {
         };
     }
 
-    pub fn get_states1(&self) -> &Vec<State> {
+    pub fn get_states1(&self) -> &Vec<State<'b>> {
         &self.states1
     }
 
-    pub fn get_states2(&self) -> &Vec<State> {
+    pub fn get_states2(&self) -> &Vec<State<'b>> {
         &self.states2
     }
 

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -35,6 +35,18 @@ impl<'b> StatePair<'b> {
         &mut self.states2
     }
 
+    //Used to allow borrowing both states as mutable
+    pub fn get_mut_states(
+        &mut self,
+        is_states1: bool,
+    ) -> (&mut Vec<State<'b>>, &mut Vec<State<'b>>) {
+        return if is_states1 {
+            (&mut self.states1, &mut self.states2)
+        } else {
+            (&mut self.states2, &mut self.states1)
+        };
+    }
+
     pub fn get_dimensions(&self) -> u32 {
         self.dimensions.clone()
     }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -133,9 +133,6 @@ fn create_new_state_pairs<'a>(
     let dim = curr_pair.get_dimensions();
     let len = dim * dim;
 
-    let mut zones_to_print1 = vec![];
-    let mut zones_to_print2 = vec![];
-
     //create guard zones left
     for (_, edge_vec1, state_index) in transitions1 {
         let state = &curr_pair.get_states1()[*state_index];
@@ -146,7 +143,6 @@ fn create_new_state_pairs<'a>(
             if g_success {
                 let inv_success = state.apply_invariant(&mut zone[0..len as usize], dim);
                 if inv_success {
-                    zones_to_print1.push(zone.clone());
                     guard_zones_left.push(zone[0..len as usize].as_mut_ptr());
                 }
             }
@@ -162,7 +158,6 @@ fn create_new_state_pairs<'a>(
             if g_success {
                 let inv_success = state.apply_invariant(&mut zone[0..len as usize], dim);
                 if inv_success {
-                    zones_to_print2.push(zone.clone());
                     guard_zones_right.push(zone[0..len as usize].as_mut_ptr());
                 }
             }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -282,8 +282,7 @@ fn create_new_state_pairs<'a>(
                 dim
             );
             if g_success {
-                let inv_success = apply_invariant(
-                    state,
+                let inv_success = state.apply_invariant(
                     &mut zone[0..len as usize],
                     dim
                 );
@@ -307,8 +306,7 @@ fn create_new_state_pairs<'a>(
                 dim
             );
             if g_success {
-                let inv_success = apply_invariant(
-                    state,
+                let inv_success = state.apply_invariant(
                     &mut zone[0..len as usize],
                     dim
                 );
@@ -480,7 +478,7 @@ fn build_state_pair<'a>(
     for (_, _, state_index) in transitions1 {
         let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         inv_success1 = inv_success1
-            && apply_invariant(state, &mut new_sp_zone, dim);
+            && state.apply_invariant(&mut new_sp_zone, dim);
         index_vec1.push(*state_index);
     }
 
@@ -491,7 +489,7 @@ fn build_state_pair<'a>(
     for (_, _, state_index) in transitions2 {
         let state = if !is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         inv_success2 = inv_success2
-            && apply_invariant(&state, &mut invariant_test, dim);
+            && state.apply_invariant(&mut invariant_test, dim);
         index_vec2.push(*state_index);
     }
     // check if newly built zones are valid
@@ -642,14 +640,15 @@ fn apply_syncs_to_comps<'a>(
             }
 
             for edge in next_edges {
+                let state = &mut states[*curr_index];
 
-                if !apply_guard(edge, &states[*curr_index], zone, dim) {
+                if !apply_guard(edge, state, zone, dim) {
                     *curr_index += 1;
                     return false;
                 }
                 
-                apply_update(edge, &mut states[*curr_index], zone, dim);
-                if !apply_invariant(&states[*curr_index], zone, dim) {
+                apply_update(edge, state, zone, dim);
+                if !state.apply_invariant(zone, dim) {
                     *curr_index += 1;
                     return false;
                 }
@@ -695,21 +694,6 @@ fn apply_update(
             zone,
             dim,
         );
-    }
-}
-
-fn apply_invariant(
-    state: &State,
-    zone: &mut [i32],
-    dim: u32,
-) -> bool {
-    if let Some(inv) = state
-        .get_location()
-        .get_invariant()
-    {
-        apply_constraints_to_state(&inv, state, zone, dim)
-    } else {
-        true
     }
 }
 

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -1,6 +1,5 @@
 use crate::DBMLib::lib;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
-use crate::EdgeEval::updater::updater;
 use crate::ModelObjects::component;
 use crate::ModelObjects::statepair::StatePair;
 use crate::ModelObjects::component::{Component, Edge, State};
@@ -432,8 +431,7 @@ fn build_state_pair<'a>(
     for (_, edge, state_index) in transitions1 {
         let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
 
-        apply_update(
-            edge,
+        edge.apply_update(
             state,
             &mut new_sp_zone,
             dim
@@ -442,8 +440,7 @@ fn build_state_pair<'a>(
     for (_, edge, state_index) in transitions2 {
         let state = if !is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
 
-        apply_update(
-            edge,
+        edge.apply_update(
             state,
             &mut new_sp_zone,
             dim
@@ -647,7 +644,7 @@ fn apply_syncs_to_comps<'a>(
                     return false;
                 }
                 
-                apply_update(edge, state, zone, dim);
+                edge.apply_update(state, zone, dim);
                 if !state.apply_invariant(zone, dim) {
                     *curr_index += 1;
                     return false;
@@ -679,22 +676,6 @@ fn apply_guard(
         true
     }
     
-}
-
-fn apply_update(
-    edge: &component::Edge,
-    state: &mut State,
-    zone: &mut [i32],
-    dim: u32,
-) {
-    if let Some(update) = edge.get_update() {
-        updater(
-            update,
-            state,
-            zone,
-            dim,
-        );
-    }
 }
 
 pub fn get_actions<'a>(

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -632,27 +632,18 @@ fn prepare_init_state(
 }
 
 fn precheck_sys_rep(sys: &mut SystemRepresentation) -> bool {
-    return match sys {
-        SystemRepresentation::Composition(left, right) => {
-            precheck_sys_rep(left) && precheck_sys_rep(right)
-        }
-        SystemRepresentation::Conjunction(left, right) => {
-            precheck_sys_rep(left) && precheck_sys_rep(right)
-        }
-        SystemRepresentation::Parentheses(val) => precheck_sys_rep(val),
-        SystemRepresentation::Component(comp) => {
-            let clock_clone = comp.get_declarations().get_clocks().clone();
+    sys.all_components(&mut |comp: &mut Component| -> bool {
+        let clock_clone = comp.get_declarations().get_clocks().clone();
 
-            let len = comp.get_mut_declaration().get_clocks().len();
-            comp.get_mut_declaration().dimension = 1 + len as u32;
+        let len = comp.get_mut_declaration().get_clocks().len();
+        comp.get_mut_declaration().dimension = 1 + len as u32;
 
-            comp.get_mut_declaration().reset_clock_indices();
+        comp.get_mut_declaration().reset_clock_indices();
 
-            let res = comp.check_consistency(true);
-            comp.get_mut_declaration().clocks = clock_clone;
-            res
-        }
-    };
+        let res = comp.check_consistency(true);
+        comp.get_mut_declaration().clocks = clock_clone;
+        res
+    })
 }
 
 fn check_preconditions(

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -274,8 +274,7 @@ fn create_new_state_pairs<'a>(
         for edge in edge_vec1 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let g_success = apply_guard(
-                edge,
+            let g_success = edge.apply_guard(
                 state,
                 &mut zone[0..len as usize],
                 dim
@@ -298,8 +297,7 @@ fn create_new_state_pairs<'a>(
         for edge in edge_vec2 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let g_success = apply_guard(
-                edge,
+            let g_success = edge.apply_guard(
                 state,
                 &mut zone[0..len as usize],
                 dim
@@ -403,8 +401,7 @@ fn build_state_pair<'a>(
         let state = if is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
 
         g1_success = g1_success
-            && apply_guard(
-                edge,
+            && edge.apply_guard(
                 state,
                 &mut new_sp_zone,
                 dim
@@ -415,8 +412,7 @@ fn build_state_pair<'a>(
         let state = if !is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
 
         g2_success = g2_success
-            && apply_guard(
-                edge,
+            && edge.apply_guard(
                 state,
                 &mut new_sp_zone,
                 dim
@@ -639,7 +635,7 @@ fn apply_syncs_to_comps<'a>(
             for edge in next_edges {
                 let state = &mut states[*curr_index];
 
-                if !apply_guard(edge, state, zone, dim) {
+                if !edge.apply_guard(state, zone, dim) {
                     *curr_index += 1;
                     return false;
                 }
@@ -660,22 +656,6 @@ fn apply_syncs_to_comps<'a>(
             return true;
         }
     }
-}
-
-fn apply_guard(
-    edge: &component::Edge,
-    state: &State,
-    zone: &mut [i32],
-    dim: u32
-) -> bool {
-    return if let Some(guard) = edge.get_guard() {
-        let success =
-            apply_constraints_to_state(guard, state, zone, dim);
-        success
-    } else {
-        true
-    }
-    
 }
 
 pub fn get_actions<'a>(

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -592,7 +592,7 @@ pub fn get_actions<'a>(
                 .into_iter()
                 .find(|location| location.get_location_type() == &component::LocationType::Initial);
             if let Some(init_loc) = init_loc {
-                let state = create_state(init_loc, comp.get_declarations().clone());
+                let state = State::create(init_loc, comp.get_declarations().clone());
                 states.push(state);
             }
         }
@@ -761,15 +761,4 @@ fn is_new_state<'a>(state_pair: &mut StatePair<'a>, passed_list: &mut Vec<StateP
         }
     }
     return true;
-}
-
-//Creates a new instance of a state
-fn create_state(
-    location: &component::Location,
-    declarations: component::Declarations,
-) -> component::State {
-    return component::State {
-        location,
-        declarations,
-    };
 }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -128,38 +128,37 @@ fn create_new_state_pairs<'a>(
     adding_input: bool,
     is_state1: bool,
 ) -> bool {
-    let mut guard_zones_left: Vec<*mut i32> = vec![];
-    let mut guard_zones_right: Vec<*mut i32> = vec![];
     let dim = curr_pair.get_dimensions();
     let len = dim * dim;
 
     //create guard zones left
+    let mut guard_zones_left: Vec<*mut i32> = vec![];
     for (_, edge_vec1, state_index) in transitions1 {
         let state = &curr_pair.get_states1()[*state_index];
         for edge in edge_vec1 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let g_success = edge.apply_guard(state, &mut zone[0..len as usize], dim);
-            if g_success {
-                let inv_success = state.apply_invariant(&mut zone[0..len as usize], dim);
-                if inv_success {
-                    guard_zones_left.push(zone[0..len as usize].as_mut_ptr());
-                }
+            //Save if edge is open
+            if edge.apply_guard(state, &mut zone[0..len as usize], dim)
+                && state.apply_invariant(&mut zone[0..len as usize], dim)
+            {
+                guard_zones_left.push(zone[0..len as usize].as_mut_ptr());
             }
         }
     }
+
     //Create guard zones right
+    let mut guard_zones_right: Vec<*mut i32> = vec![];
     for (_, edge_vec2, state_index) in transitions2 {
         let state = &curr_pair.get_states2()[*state_index];
         for edge in edge_vec2 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let g_success = edge.apply_guard(state, &mut zone[0..len as usize], dim);
-            if g_success {
-                let inv_success = state.apply_invariant(&mut zone[0..len as usize], dim);
-                if inv_success {
-                    guard_zones_right.push(zone[0..len as usize].as_mut_ptr());
-                }
+            //Save if edge is open
+            if edge.apply_guard(state, &mut zone[0..len as usize], dim)
+                && state.apply_invariant(&mut zone[0..len as usize], dim)
+            {
+                guard_zones_right.push(zone[0..len as usize].as_mut_ptr());
             }
         }
     }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -2,7 +2,8 @@ use crate::DBMLib::lib;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 use crate::EdgeEval::updater::updater;
 use crate::ModelObjects::component;
-use crate::ModelObjects::component::{Component, Edge, State, StatePair};
+use crate::ModelObjects::statepair::StatePair;
+use crate::ModelObjects::component::{Component, Edge, State};
 use crate::ModelObjects::representations::SystemRepresentation;
 use crate::ModelObjects::system_declarations;
 use std::cell::Cell;
@@ -41,7 +42,7 @@ pub fn check_refinement(
 
     //Firstly we check the preconditions
 
-    let mut initial_pair = create_state_pair(initial_states_1.clone(), initial_states_2.clone());
+    let mut initial_pair = StatePair::create(initial_states_1.clone(), initial_states_2.clone());
     initial_pair.init_dbm();
     prepare_init_state(&mut initial_pair, initial_states_1, initial_states_2);
     waiting_list.push(initial_pair);
@@ -384,7 +385,7 @@ fn build_state_pair<'a>(
 ) -> bool {
     //Creates new state pair
     let mut new_sp: StatePair =
-        create_state_pair(curr_pair.states1.clone(), curr_pair.states2.clone());
+        StatePair::create(curr_pair.states1.clone(), curr_pair.states2.clone());
     //Creates DBM for that sate pair
     let mut new_sp_zone = curr_pair.get_dbm_clone();
     new_sp.set_dimensions(curr_pair.get_dimensions());
@@ -947,7 +948,7 @@ pub fn find_extra_input_output(
 }
 
 fn is_new_state<'a>(
-    state_pair: &mut component::StatePair<'a>,
+    state_pair: &mut StatePair<'a>,
     passed_list: &mut Vec<StatePair<'a>>,
 ) -> bool {
     'OuterFor: for passed_state_pair in passed_list {
@@ -996,12 +997,4 @@ fn create_state(
     };
 }
 
-//Creates a new instance of a state pair
-fn create_state_pair<'a>(state1: Vec<State<'a>>, state2: Vec<State<'a>>) -> StatePair<'a> {
-    return StatePair {
-        states1: state1,
-        states2: state2,
-        zone: [0; 1000],
-        dimensions: 0,
-    };
-}
+

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -5,12 +5,11 @@ use crate::ModelObjects::component::{Component, Edge, State};
 use crate::ModelObjects::representations::SystemRepresentation;
 use crate::ModelObjects::statepair::StatePair;
 use crate::ModelObjects::system_declarations;
-use std::cell::Cell;
 
 //------------------ NEW IMPL ------------------
 pub fn check_refinement(
-    mut sys1: SystemRepresentation,
-    mut sys2: SystemRepresentation,
+    sys1: SystemRepresentation,
+    sys2: SystemRepresentation,
     sys_decls: &system_declarations::SystemDeclarations,
 ) -> Result<bool, String> {
     let mut passed_list: Vec<StatePair> = vec![];

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -89,7 +89,7 @@ pub fn check_refinement(
                     if !create_new_state_pairs(
                         &combined_transitions1,
                         &combined_transitions2,
-                        &curr_pair,
+                        &mut curr_pair,
                         &mut waiting_list,
                         &mut passed_list,
                         &sys1,
@@ -173,7 +173,6 @@ pub fn check_refinement(
     return Ok(true);
 }
 
-
 fn collect_open_edges<'a>(
     sys: &'a SystemRepresentation,
     curr_pair: &StatePair<'a>,
@@ -248,7 +247,7 @@ fn collect_open_edges<'a>(
 fn create_new_state_pairs<'a>(
     transitions1: &Vec<(&'a Component, Vec<&'a Edge>, usize)>,
     transitions2: &Vec<(&'a Component, Vec<&'a Edge>, usize)>,
-    curr_pair: & StatePair<'a>,
+    curr_pair: &mut StatePair<'a>,
     waiting_list: &mut Vec<StatePair<'a>>,
     passed_list: &mut Vec<StatePair<'a>>,
     sys1: &'a SystemRepresentation,
@@ -270,18 +269,21 @@ fn create_new_state_pairs<'a>(
         for edge in edge_vec1 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let state = &curr_pair.get_states1()[*state_index];
             let g_success = apply_guard(
                 edge,
-                state,
+                &curr_pair,
                 &mut zone[0..len as usize],
-                dim
+                dim,
+                *state_index,
+                true,
             );
             if g_success {
                 let inv_success = apply_invariant(
-                    state,
+                    &curr_pair,
                     &mut zone[0..len as usize],
-                    dim
+                    dim,
+                    *state_index,
+                    true,
                 );
                 if inv_success {
                     zones_to_print1.push(zone.clone());
@@ -295,18 +297,21 @@ fn create_new_state_pairs<'a>(
         for edge in edge_vec2 {
             let mut zone = curr_pair.get_dbm_clone();
 
-            let state = &curr_pair.get_states2()[*state_index];
             let g_success = apply_guard(
                 edge,
-                state,
+                &curr_pair,
                 &mut zone[0..len as usize],
-                dim
+                dim,
+                *state_index,
+                false,
             );
             if g_success {
                 let inv_success = apply_invariant(
-                    state,
+                    &curr_pair,
                     &mut zone[0..len as usize],
-                    dim
+                    dim,
+                    *state_index,
+                    false,
                 );
                 if inv_success {
                     zones_to_print2.push(zone.clone());
@@ -393,52 +398,58 @@ fn build_state_pair<'a>(
     new_sp.set_dimensions(curr_pair.get_dimensions());
     let dim = new_sp.get_dimensions();
     //Apply guards on both sides
+    //Boolean for the left side guards
+    let mut g1_success = true;
+    //Boolean for the right side guards
+    let mut g2_success = true;
     //Applies the left side guards and checks if zone is valid
     for (_, edge, state_index) in transitions1 {
-        let state = if is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
-
-        if !apply_guard(
-            edge,
-            state,
-            &mut new_sp_zone,
-            dim
-        ){
-            return false;
-        }
+        g1_success = g1_success
+            && apply_guard(
+                edge,
+                &new_sp,
+                &mut new_sp_zone,
+                dim,
+                *state_index,
+                is_state1,
+            );
     }
-
     //Applies the right side guards and checks if zone is valid
-    let g2_success = true;
     for (_, edge, state_index) in transitions2 {
-        let state = if !is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
-
-        if !apply_guard(
-            edge,
-            state,
-            &mut new_sp_zone,
-            dim
-        ){
-            return false;
-        }
+        g2_success = g2_success
+            && apply_guard(
+                edge,
+                &new_sp,
+                &mut new_sp_zone,
+                dim,
+                *state_index,
+                !is_state1,
+            );
+    }
+    //Fails the refinement if at any point the zone was invalid
+    if !g1_success || !g2_success {
+        return false;
     }
 
     //Apply updates on both sides
     for (_, edge, state_index) in transitions1 {
-        let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         apply_update(
             edge,
-            state,
+            &mut new_sp,
             &mut new_sp_zone,
             dim,
+            *state_index,
+            is_state1,
         );
     }
     for (_, edge, state_index) in transitions2 {
-        let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         apply_update(
             edge,
-            state,
+            &mut new_sp,
             &mut new_sp_zone,
-            dim
+            dim,
+            *state_index,
+            !is_state1,
         );
     }
 
@@ -468,10 +479,8 @@ fn build_state_pair<'a>(
     let mut inv_success1 = true;
     let mut index_vec1: Vec<usize> = vec![];
     for (_, _, state_index) in transitions1 {
-        let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
-
         inv_success1 = inv_success1
-            && apply_invariant(state, &mut new_sp_zone, dim);
+            && apply_invariant(&new_sp, &mut new_sp_zone, dim, *state_index, is_state1);
         index_vec1.push(*state_index);
     }
 
@@ -480,10 +489,8 @@ fn build_state_pair<'a>(
     let mut index_vec2: Vec<usize> = vec![];
     let mut invariant_test = new_sp_zone.clone();
     for (_, _, state_index) in transitions2 {
-        let state = if !is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
-
         inv_success2 = inv_success2
-            && apply_invariant(state, &mut invariant_test, dim);
+            && apply_invariant(&new_sp, &mut invariant_test, dim, *state_index, !is_state1);
         index_vec2.push(*state_index);
     }
     // check if newly built zones are valid
@@ -651,14 +658,12 @@ fn apply_syncs_to_comps<'a>(
             }
 
             for edge in next_edges {
-                let state = if is_state1 {&mut new_sp.get_mut_states1()[*curr_index]} else {&mut new_sp.get_mut_states2()[*curr_index]};
-
-                if !apply_guard(edge, &*state, zone, dim) {
+                if !apply_guard(edge, new_sp, zone, dim, *curr_index, is_state1) {
                     *curr_index += 1;
                     return false;
                 }
-                apply_update(edge, state, zone, dim);
-                if !apply_invariant(&*state, zone, dim) {
+                apply_update(edge, new_sp, zone, dim, *curr_index, is_state1);
+                if !apply_invariant(new_sp, zone, dim, *curr_index, is_state1) {
                     *curr_index += 1;
                     return false;
                 }
@@ -680,46 +685,87 @@ fn apply_syncs_to_comps<'a>(
 
 fn apply_guard(
     edge: &component::Edge,
-    state: &State,
+    new_sp: &StatePair,
     zone: &mut [i32],
     dim: u32,
+    state_index: usize,
+    is_state1: bool,
 ) -> bool {
-    return if let Some(guard) = edge.get_guard() {
-        apply_constraints_to_state(guard, state, zone, dim)
-    }else{
-        true
-    }
+    return if is_state1 {
+        if let Some(guard) = edge.get_guard() {
+            let success =
+                apply_constraints_to_state(guard, &new_sp.get_states1()[state_index], zone, dim);
+            success
+        } else {
+            true
+        }
+    } else {
+        if let Some(guard) = edge.get_guard() {
+            let success =
+                apply_constraints_to_state(guard, &new_sp.get_states2()[state_index], zone, dim);
+            success
+        } else {
+            true
+        }
+    };
 }
 
 fn apply_update(
     edge: &component::Edge,
-    state: &mut State,
+    new_sp: &mut StatePair,
     zone: &mut [i32],
-    dim: u32
+    dim: u32,
+    state_index: usize,
+    is_state1: bool,
 ) {
-    if let Some(update) = edge.get_update() {
-        updater(
-            update,
-            state,
-            zone,
-            dim,
-        );
+    if is_state1 {
+        if let Some(update) = edge.get_update() {
+            updater(
+                update,
+                &mut new_sp.get_mut_states1()[state_index],
+                zone,
+                dim,
+            );
+        }
+    } else {
+        if let Some(update) = edge.get_update() {
+            updater(
+                update,
+                &mut new_sp.get_mut_states2()[state_index],
+                zone,
+                dim,
+            );
+        }
     }
 }
 
 fn apply_invariant(
-    state: &State,
+    new_sp: &StatePair,
     zone: &mut [i32],
-    dim: u32
+    dim: u32,
+    state_index: usize,
+    is_state1: bool,
 ) -> bool {
-    return if let Some(inv) = state
-        .get_location()
-        .get_invariant()
-    {
-        apply_constraints_to_state(&inv, state, zone, dim)
+    return if is_state1 {
+        if let Some(inv) = new_sp.get_states1()[state_index]
+            .get_location()
+            .get_invariant()
+        {
+            apply_constraints_to_state(&inv, &new_sp.get_states1()[state_index], zone, dim)
+        } else {
+            true
+        }
     } else {
-        true
-    }
+        if let Some(inv) = new_sp.get_states2()[state_index]
+            .get_location()
+            .get_invariant()
+        {
+            println!("applying invariant state2 {:?}", inv);
+            apply_constraints_to_state(&inv, &new_sp.get_states2()[state_index], zone, dim)
+        } else {
+            true
+        }
+    };
 }
 
 pub fn get_actions<'a>(

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -6,7 +6,6 @@ use crate::ModelObjects::representations::SystemRepresentation;
 use crate::ModelObjects::statepair::StatePair;
 use crate::ModelObjects::system_declarations;
 
-//------------------ NEW IMPL ------------------
 pub fn check_refinement(
     sys1: SystemRepresentation,
     sys2: SystemRepresentation,
@@ -364,24 +363,18 @@ fn apply_syncs_to_comps<'a>(
 
     // Recursively goes through system representation
     sys.any_composition(&mut |comp: &Component| -> bool {
-        let mut next_edges = vec![];
-        let mut should_break = false;
         let sync_type = if adding_input {
             component::SyncType::Output
         } else {
             component::SyncType::Input
         };
 
-        if !index_vec.contains(curr_index) {
-            next_edges = comp.get_next_edges(states[*curr_index].get_location(), action, sync_type);
-        } else {
-            should_break = true;
-        }
-
-        if should_break {
+        if index_vec.contains(curr_index) {
             *curr_index += 1;
             return true;
         }
+
+        let next_edges = comp.get_next_edges(states[*curr_index].get_location(), action, sync_type);
         if next_edges.len() < 1 {
             *curr_index += 1;
             return false;

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -271,24 +271,21 @@ fn create_new_state_pairs<'a>(
 
     //create guard zones left
     for (_, edge_vec1, state_index) in transitions1 {
+        let state = &curr_pair.get_states1()[*state_index];
         for edge in edge_vec1 {
             let mut zone = curr_pair.get_dbm_clone();
 
             let g_success = apply_guard(
                 edge,
-                &curr_pair,
+                state,
                 &mut zone[0..len as usize],
-                dim,
-                *state_index,
-                true,
+                dim
             );
             if g_success {
                 let inv_success = apply_invariant(
-                    &curr_pair,
+                    state,
                     &mut zone[0..len as usize],
-                    dim,
-                    *state_index,
-                    true,
+                    dim
                 );
                 if inv_success {
                     zones_to_print1.push(zone.clone());
@@ -299,24 +296,21 @@ fn create_new_state_pairs<'a>(
     }
     //Create guard zones right
     for (_, edge_vec2, state_index) in transitions2 {
+        let state = &curr_pair.get_states2()[*state_index];
         for edge in edge_vec2 {
             let mut zone = curr_pair.get_dbm_clone();
 
             let g_success = apply_guard(
                 edge,
-                &curr_pair,
+                state,
                 &mut zone[0..len as usize],
-                dim,
-                *state_index,
-                false,
+                dim
             );
             if g_success {
                 let inv_success = apply_invariant(
-                    &curr_pair,
+                    state,
                     &mut zone[0..len as usize],
-                    dim,
-                    *state_index,
-                    false,
+                    dim
                 );
                 if inv_success {
                     zones_to_print2.push(zone.clone());
@@ -409,26 +403,26 @@ fn build_state_pair<'a>(
     let mut g2_success = true;
     //Applies the left side guards and checks if zone is valid
     for (_, edge, state_index) in transitions1 {
+        let state = if is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
+
         g1_success = g1_success
             && apply_guard(
                 edge,
-                &new_sp,
+                state,
                 &mut new_sp_zone,
-                dim,
-                *state_index,
-                is_state1,
+                dim
             );
     }
     //Applies the right side guards and checks if zone is valid
     for (_, edge, state_index) in transitions2 {
+        let state = if !is_state1 {&new_sp.get_states1()[*state_index]} else {&new_sp.get_states2()[*state_index]};
+
         g2_success = g2_success
             && apply_guard(
                 edge,
-                &new_sp,
+                state,
                 &mut new_sp_zone,
-                dim,
-                *state_index,
-                !is_state1,
+                dim
             );
     }
     //Fails the refinement if at any point the zone was invalid
@@ -438,23 +432,23 @@ fn build_state_pair<'a>(
 
     //Apply updates on both sides
     for (_, edge, state_index) in transitions1 {
+        let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
+
         apply_update(
             edge,
-            &mut new_sp,
+            state,
             &mut new_sp_zone,
-            dim,
-            *state_index,
-            is_state1,
+            dim
         );
     }
     for (_, edge, state_index) in transitions2 {
+        let state = if !is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
+
         apply_update(
             edge,
-            &mut new_sp,
+            state,
             &mut new_sp_zone,
-            dim,
-            *state_index,
-            !is_state1,
+            dim
         );
     }
 
@@ -484,8 +478,9 @@ fn build_state_pair<'a>(
     let mut inv_success1 = true;
     let mut index_vec1: Vec<usize> = vec![];
     for (_, _, state_index) in transitions1 {
+        let state = if is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         inv_success1 = inv_success1
-            && apply_invariant(&new_sp, &mut new_sp_zone, dim, *state_index, is_state1);
+            && apply_invariant(state, &mut new_sp_zone, dim);
         index_vec1.push(*state_index);
     }
 
@@ -494,8 +489,9 @@ fn build_state_pair<'a>(
     let mut index_vec2: Vec<usize> = vec![];
     let mut invariant_test = new_sp_zone.clone();
     for (_, _, state_index) in transitions2 {
+        let state = if !is_state1 {&mut new_sp.get_mut_states1()[*state_index]} else {&mut new_sp.get_mut_states2()[*state_index]};
         inv_success2 = inv_success2
-            && apply_invariant(&new_sp, &mut invariant_test, dim, *state_index, !is_state1);
+            && apply_invariant(&state, &mut invariant_test, dim);
         index_vec2.push(*state_index);
     }
     // check if newly built zones are valid
@@ -663,12 +659,15 @@ fn apply_syncs_to_comps<'a>(
             }
 
             for edge in next_edges {
-                if !apply_guard(edge, new_sp, zone, dim, *curr_index, is_state1) {
+                let state = if is_state1 {&new_sp.get_states1()[*curr_index]} else {&new_sp.get_states2()[*curr_index]};
+
+                if !apply_guard(edge, state, zone, dim) {
                     *curr_index += 1;
                     return false;
                 }
-                apply_update(edge, new_sp, zone, dim, *curr_index, is_state1);
-                if !apply_invariant(new_sp, zone, dim, *curr_index, is_state1) {
+                let state = if is_state1 {&mut new_sp.get_mut_states1()[*curr_index]} else {&mut new_sp.get_mut_states2()[*curr_index]};
+                apply_update(edge, state, zone, dim);
+                if !apply_invariant(&state, zone, dim) {
                     *curr_index += 1;
                     return false;
                 }
@@ -690,87 +689,49 @@ fn apply_syncs_to_comps<'a>(
 
 fn apply_guard(
     edge: &component::Edge,
-    new_sp: &StatePair,
+    state: &State,
     zone: &mut [i32],
-    dim: u32,
-    state_index: usize,
-    is_state1: bool,
+    dim: u32
 ) -> bool {
-    return if is_state1 {
-        if let Some(guard) = edge.get_guard() {
-            let success =
-                apply_constraints_to_state(guard, &new_sp.get_states1()[state_index], zone, dim);
-            success
-        } else {
-            true
-        }
+    return if let Some(guard) = edge.get_guard() {
+        let success =
+            apply_constraints_to_state(guard, state, zone, dim);
+        success
     } else {
-        if let Some(guard) = edge.get_guard() {
-            let success =
-                apply_constraints_to_state(guard, &new_sp.get_states2()[state_index], zone, dim);
-            success
-        } else {
-            true
-        }
-    };
+        true
+    }
+    
 }
 
 fn apply_update(
     edge: &component::Edge,
-    new_sp: &mut StatePair,
+    state: &mut State,
     zone: &mut [i32],
     dim: u32,
-    state_index: usize,
-    is_state1: bool,
 ) {
-    if is_state1 {
-        if let Some(update) = edge.get_update() {
-            updater(
-                update,
-                &mut new_sp.get_mut_states1()[state_index],
-                zone,
-                dim,
-            );
-        }
-    } else {
-        if let Some(update) = edge.get_update() {
-            updater(
-                update,
-                &mut new_sp.get_mut_states2()[state_index],
-                zone,
-                dim,
-            );
-        }
+    if let Some(update) = edge.get_update() {
+        updater(
+            update,
+            state,
+            zone,
+            dim,
+        );
     }
 }
 
 fn apply_invariant(
-    new_sp: &StatePair,
+    state: &State,
     zone: &mut [i32],
     dim: u32,
-    state_index: usize,
-    is_state1: bool,
 ) -> bool {
-    return if is_state1 {
-        if let Some(inv) = new_sp.get_states1()[state_index]
-            .get_location()
-            .get_invariant()
-        {
-            apply_constraints_to_state(&inv, &new_sp.get_states1()[state_index], zone, dim)
-        } else {
-            true
-        }
+    if let Some(inv) = state
+        .get_location()
+        .get_invariant()
+    {
+        apply_constraints_to_state(&inv, state, zone, dim)
     } else {
-        if let Some(inv) = new_sp.get_states2()[state_index]
-            .get_location()
-            .get_invariant()
-        {
-            println!("applying invariant state2 {:?}", inv);
-            apply_constraints_to_state(&inv, &new_sp.get_states2()[state_index], zone, dim)
-        } else {
-            true
-        }
-    };
+        true
+    }
 }
 
 pub fn get_actions<'a>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,13 +53,11 @@ pub fn main() {
                     let inputs2 = sys2.get_input_actions(&system_declarations);
                     let outputs1 = system_rep_tuple.0.get_output_actions(&system_declarations);
 
-                    let (extra_o, extra_i) = refine::find_extra_input_output(
-                        &system_rep_tuple.0,
-                        &sys2,
-                        &outputs1,
-                        &inputs2,
-                        &system_declarations,
-                    );
+                    let extra_i = system_rep_tuple
+                        .0
+                        .find_matching_input(&system_declarations, &inputs2);
+                    let extra_o = sys2.find_matching_output(&system_declarations, &outputs1);
+
                     println!("extra outputs {:?}", extra_o);
                     println!("extra inputs {:?}", extra_i);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod ModelObjects;
 mod System;
 mod tests;
 
-use crate::ModelObjects::component::State;
 use crate::ModelObjects::parse_queries;
 use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::xml_parser;
@@ -51,24 +50,9 @@ pub fn main() {
                         Err(err_msg) => println!("{}", err_msg),
                     }
                 } else {
-                    let mut inputs2: Vec<String> = vec![];
-                    let mut outputs1: Vec<String> = vec![];
-                    let mut initial_states_1: Vec<State> = vec![];
-                    let mut initial_states_2: Vec<State> = vec![];
-                    refine::get_actions(
-                        &sys2,
-                        &system_declarations,
-                        true,
-                        &mut inputs2,
-                        &mut initial_states_2,
-                    );
-                    refine::get_actions(
-                        &system_rep_tuple.0,
-                        &system_declarations,
-                        false,
-                        &mut outputs1,
-                        &mut initial_states_1,
-                    );
+                    let inputs2 = sys2.get_input_actions(&system_declarations);
+                    let outputs1 = system_rep_tuple.0.get_output_actions(&system_declarations);
+
                     let (extra_o, extra_i) = refine::find_extra_input_output(
                         &system_rep_tuple.0,
                         &sys2,


### PR DESCRIPTION
The primary goal of this pull request is to try and generalize the code in refine.rs so it can be moved away from this file and potentially reused later.

Some of main changes have been:

- Currently a lot of effort has gone into simplifying functions, by reducing parameter count and splitting functions with multiple uses into separate functions. As a part of this `is_state1` and other boolean flags have been a main priority.

- The static variables were also replaced with local variables, although something is still failing when running tests with more than one thread. My uneducated guess would be the udbm library causing problems?

- Moved code away from the refine.rs file, notably:
-- Any zone modifying function has been moved to edge and state impl respectively.
-- Constructors moved to their impl
-- `SystemRepresentation `navigation logic is moved to `SystemRepresentation `impl and is used with lambdas
-- Parsing functions are moved to `SystemRepresentation` here in: `GetActions` and `Collect_Open_Edges`


Work is still needed, especially on `create_new_state_pairs` and  `build_state_pair`

I've decided to leave them for now, as optimal fixes requires better domain knowledge.