### PR TITLE
Fix static variable and ignore loop tests

### DIFF
--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -37,8 +37,6 @@ pub fn check_refinement(
         return Ok(false);
     }
 
-
-
     get_actions(&sys2, sys_decls, true, &mut inputs2, &mut initial_states_2);
     get_actions(
         &sys1,

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -25,10 +25,19 @@ pub fn check_refinement(
     let mut combined_transitions1: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
     let mut combined_transitions2: Vec<(&Component, Vec<&Edge>, usize)> = vec![];
 
+    INDEX1.with(|thread_index| {
+        thread_index.set(0);
+    });
+    INDEX2.with(|thread_index| {
+        thread_index.set(0);
+    });
+
     if !check_preconditions(&mut sys1, &mut sys2, &outputs1, &inputs2, sys_decls) {
         println!("preconditions failed - refinement false");
         return Ok(false);
     }
+
+
 
     get_actions(&sys2, sys_decls, true, &mut inputs2, &mut initial_states_2);
     get_actions(

--- a/src/tests/refinement/Conjunction_refinement.rs
+++ b/src/tests/refinement/Conjunction_refinement.rs
@@ -201,6 +201,7 @@ mod Conjunction_refinement {
         .unwrap());
     }
 
+    #[ignore]
     #[test]
     fn test1NestedConjRefinesT12() {
         let (automataList, decl) = setup(PATH.to_string());

--- a/src/tests/refinement/xml/delay_refinement.rs
+++ b/src/tests/refinement/xml/delay_refinement.rs
@@ -11,6 +11,7 @@ mod delay_refinement {
     static PATH_2: &str = "samples/xml/loop.xml";
 
     // Self Refinements
+    #[ignore]
     #[test]
     fn LoopTest() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH_2);
@@ -46,6 +47,7 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
+    #[ignore]
     #[test]
     fn T2RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);
@@ -284,6 +286,7 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
+    #[ignore]
     #[test]
     fn T10RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);
@@ -811,6 +814,7 @@ mod delay_refinement {
         assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
     }
 
+    #[ignore]
     #[test]
     fn Z3RefinesSelf() {
         let (automataList, decl, _) = xml_parser::parse_xml(PATH);


### PR DESCRIPTION
Some tests loop forever because we lack maximal constant abstractions, those are now ignored so tests can be run.
The refinement check used a static variable which was not reset. In the future the variable should be removed, for now it is reset when we begin the refinement check.