### PR TITLE
Fixed conjunction tests

### DIFF
--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -39,6 +39,14 @@ impl<'b> StatePair<'b> {
         }
     }
 
+    pub fn get_states(&self, is_states1: bool) -> (&Vec<State<'b>>, &Vec<State<'b>>) {
+        if is_states1 {
+            (&self.states1, &self.states2)
+        } else {
+            (&self.states2, &self.states1)
+        }
+    }
+
     pub fn get_dimensions(&self) -> u32 {
         self.dimensions
     }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -130,10 +130,12 @@ fn create_new_state_pairs<'a>(
     let dim = curr_pair.get_dimensions();
     let len = dim * dim;
 
+    let (states1, states2) = curr_pair.get_states(is_state1);
+
     //create guard zones left
     let mut guard_zones_left: Vec<*mut i32> = vec![];
     for (_, edge_vec1, state_index) in transitions1 {
-        let state = &curr_pair.get_states1()[*state_index];
+        let state = &states1[*state_index];
         for edge in edge_vec1 {
             let mut zone = curr_pair.get_dbm_clone();
 
@@ -149,7 +151,7 @@ fn create_new_state_pairs<'a>(
     //Create guard zones right
     let mut guard_zones_right: Vec<*mut i32> = vec![];
     for (_, edge_vec2, state_index) in transitions2 {
-        let state = &curr_pair.get_states2()[*state_index];
+        let state = &states2[*state_index];
         for edge in edge_vec2 {
             let mut zone = curr_pair.get_dbm_clone();
 
@@ -486,7 +488,7 @@ fn is_new_state<'a>(state_pair: &mut StatePair<'a>, passed_list: &mut Vec<StateP
             }
         }
 
-        for i in 0..passed_state_pair.get_states1().len() {
+        for i in 0..passed_state_pair.get_states2().len() {
             if passed_state_pair.get_states2()[i].get_location().get_id()
                 != state_pair.get_states2()[i].get_location().get_id()
             {


### PR DESCRIPTION
Fixes to errors found relating to conjunction tests fixes #21
These changes depend on PR #20

These changes make most conjunction refinement checks pass.
This also unexpectedly made the test `Refinement_university::testMachine3RefinesMachine` pass aswell

The following conjunctions tests still fail:
`Refinement_university::testAdm2RefinesHalf1AndHalf2`
`Refinement_university::testHalf1AndHalf2RefinesAdm2`
But with further investigation they fail due to determinism checks so this problem might already be solved in #19 


With these changes we're down to 28 failing tests and 3 ignored