### PR TITLE
Improved continuous integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 on:
-  - pull_request
+  - push
 
 name: Validation
 


### PR DESCRIPTION
This is a fix to a problem that has been annoying me. Due to the old CI `on` event CI wouldnt run whenever master is updated meaning we lose out on this convenient functionality to check the tests on the latest commit:
![image](https://user-images.githubusercontent.com/10059450/122676533-d156be80-d1de-11eb-85f6-0fb524eb163c.png)
