### PR TITLE
Fixing Tests

### DIFF
--- a/src/tests/refinement/AG_Tests.rs
+++ b/src/tests/refinement/AG_Tests.rs
@@ -1,196 +1,81 @@
 #[cfg(test)]
 mod AG_Tests {
-    use crate::tests::refinement::Helper::setup;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/AG";
 
     #[test]
     fn ARefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("A").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("A").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: A <= A"));
     }
 
     #[test]
     fn GRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: G <= G"));
     }
 
     #[test]
     fn QRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Q <= Q"));
     }
 
     #[test]
     fn ImpRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Imp <= Imp"));
     }
 
     #[test]
     fn AaRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("AA").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("AA").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: AA <= AA"));
     }
 
     #[test]
     fn AGNotRefinesAImp() {
+        assert!(!json_refinement_check(PATH, "refinement: A||G <= A||Imp"));
         // should fail because left side has more inputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Composition(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("A").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("G").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Composition(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("A").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Imp").unwrap().clone()
-                ))
-            ),
-            decl.borrow()
-        )
-        .unwrap());
     }
 
     #[test]
     fn AImpNotRefinesAG() {
+        assert!(!json_refinement_check(PATH, "refinement: A||Imp <= A||G"));
         // should fail because the right side has more inputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Composition(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("A").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Imp").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Composition(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("A").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("G").unwrap().clone()
-                ))
-            ),
-            decl.borrow()
-        )
-        .unwrap());
     }
 
     #[test]
     fn GNotRefinesImp() {
+        assert!(!json_refinement_check(PATH, "refinement: G <= Imp"));
         // should fail because right side has more outputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
     }
 
     #[test]
     fn ImpRefinesG() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Imp <= G"));
     }
 
     #[test]
     fn GRefinesQ() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: G <= Q"));
     }
 
     #[test]
     fn QRefinesG() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("G").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Q <= G"));
     }
 
     #[test]
     fn QNotRefinesImp() {
         // should fail because right side has more outputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Q <= Imp"));
     }
 
     #[test]
     fn ImpRefinesQ() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Imp").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Q").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Imp <= Q"));
     }
 
     #[test]
     fn ANotRefinesAA() {
+        assert!(!json_refinement_check(PATH, "refinement: A <= AA"));
         // should fail because right side has more inputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("A").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("AA").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
     }
 }

--- a/src/tests/refinement/Big_Refinement.rs
+++ b/src/tests/refinement/Big_Refinement.rs
@@ -1,54 +1,27 @@
 #[cfg(test)]
 mod Big_refinement {
-    use crate::tests::refinement::Helper::setup;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/BigRefinement";
 
     #[test]
     fn testRef1NotRefinesComp1() {
         // should fail because left side has more inputs
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Ref1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Comp1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Ref1 <= Comp1"));
     }
 
     #[test]
     fn testComp1NotRefinesRef1() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Comp1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Ref1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Comp1 <= Ref1"));
     }
 
     #[test]
     fn testRef1RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Ref1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Ref1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Ref1 <= Ref1"));
     }
 
     #[test]
     fn testComp1RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Comp1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Comp1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Comp1 <= Comp1"));
     }
 }

--- a/src/tests/refinement/Conjunction_refinement.rs
+++ b/src/tests/refinement/Conjunction_refinement.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod Conjunction_refinement {
-    use crate::tests::refinement::Helper::setup;
+    use crate::tests::refinement::Helper::json_refinement_check;
     use crate::ModelObjects::representations::SystemRepresentation;
     use crate::System::refine;
     use std::borrow::Borrow;
@@ -9,222 +9,83 @@ mod Conjunction_refinement {
 
     #[test]
     fn T1RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Test1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Test1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Test1 <= Test1"));
     }
 
     #[test]
     fn T2RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Test2").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Test2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Test2 <= Test2"));
     }
 
     #[test]
     fn T3RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Test3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Test3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Test3 <= Test3"));
     }
 
     #[test]
     fn T4RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Test4").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Test4").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Test4 <= Test4"));
     }
 
     #[test]
     fn T5RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Test5").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Test5").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Test5 <= Test5"));
     }
 
     #[test]
     fn T1ConjT2RefinesT3() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test1").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test2").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test1 && Test2 <= Test3"
+        ));
     }
 
     #[test]
     fn T2ConjT3RefinesT1() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test2").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test3").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test2 && Test3 <= Test1"
+        ));
     }
 
     #[test]
     fn T1ConjT3RefinesT2() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test1").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test3").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test1 && Test3 <= Test2"
+        ));
     }
 
     #[test]
     fn T1ConjT2ConjT4RefinesT5() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Conjunction(
-                    Box::from(SystemRepresentation::Component(
-                        automataList.get("Test1").unwrap().clone()
-                    )),
-                    Box::from(SystemRepresentation::Component(
-                        automataList.get("Test2").unwrap().clone()
-                    ))
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test4").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test5").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test1 && Test2 && Test4 <= Test5"
+        ));
     }
 
     #[test]
     fn T3ConjT4RefinesT5() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test3").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test4").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test5").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
-    }
-
-    #[test]
-    fn test1NestedConjRefinesT5() {
-        let (automataList, decl) = setup(PATH.to_string());
-        let ts1 = SystemRepresentation::Conjunction(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test1").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test2").unwrap().clone(),
-            )),
-        );
-        let ts2: SystemRepresentation = SystemRepresentation::Conjunction(
-            Box::from(ts1),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test4").unwrap().clone(),
-            )),
-        );
-
-        assert!(refine::check_refinement(
-            ts2,
-            SystemRepresentation::Component(automataList.get("Test5").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test3 && Test4 <= Test5"
+        ));
     }
 
     #[ignore] //Ignored because it crashses test framework
     #[test]
     fn T6ConjT7RefinesT8() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test6").unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Test7").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Test8").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test6 && Test7 <= Test8"
+        ));
     }
 
     #[test]
     fn test1NestedConjRefinesT12() {
-        let (automataList, decl) = setup(PATH.to_string());
-        let ts1 = SystemRepresentation::Conjunction(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test9").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test10").unwrap().clone(),
-            )),
-        );
-        let ts2: SystemRepresentation = SystemRepresentation::Conjunction(
-            Box::from(ts1),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Test11").unwrap().clone(),
-            )),
-        );
-
-        assert!(refine::check_refinement(
-            ts2,
-            SystemRepresentation::Component(automataList.get("Test12").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Test9 && Test10 && Test11 <= Test12"
+        ));
     }
 }

--- a/src/tests/refinement/Helper.rs
+++ b/src/tests/refinement/Helper.rs
@@ -1,12 +1,16 @@
 use crate::read_input;
 use crate::ModelObjects::component::Component;
+use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
+use crate::ModelObjects::{parse_queries, xml_parser};
+use crate::System::extract_system_rep::create_system_rep_from_query;
 use crate::System::input_enabler;
+use crate::System::refine;
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::{fs, io};
 
 pub fn setup(mut folder_path: String) -> (HashMap<String, Component>, SystemDeclarations) {
-    println!("refTest()");
     //let mut folder_path: String = "../samples/xml/delayRefinement.xml".to_string();
     //let mut folder_path: String = "samples/json/AG".to_string();
     let mut paths = fs::read_dir(&folder_path)
@@ -40,6 +44,35 @@ pub fn setup(mut folder_path: String) -> (HashMap<String, Component>, SystemDecl
     (comp_map, system_declarations.clone())
 }
 
+pub fn json_setup(mut folder_path: String) -> (Vec<Component>, SystemDeclarations) {
+    //let mut folder_path: String = "../samples/xml/delayRefinement.xml".to_string();
+    //let mut folder_path: String = "samples/json/AG".to_string();
+    let mut paths = fs::read_dir(&folder_path)
+        .unwrap()
+        .map(|res| res.map(|e| e.path()))
+        .filter(|x| !(x.as_ref().unwrap().is_dir()))
+        .collect::<Result<Vec<_>, io::Error>>()
+        .unwrap();
+
+    folder_path.push_str("/Components");
+
+    let mut components = fs::read_dir(folder_path)
+        .unwrap()
+        .map(|res| res.map(|e| e.path()))
+        .filter(|x| !(x.as_ref().unwrap().is_dir()))
+        .collect::<Result<Vec<_>, io::Error>>()
+        .unwrap();
+
+    paths.sort();
+    components.sort();
+
+    let (comps, system_declarations, _queries) = read_input(paths, components).unwrap();
+
+    let optimized_comps = optimize_components(comps, &system_declarations);
+
+    (optimized_comps, system_declarations.clone())
+}
+
 pub fn optimize_components(
     automataList: Vec<Component>,
     decl: &SystemDeclarations,
@@ -51,4 +84,33 @@ pub fn optimize_components(
         optimized_components.push(optimized_comp);
     }
     optimized_components
+}
+
+pub fn xml_refinement_check(PATH: &str, QUERY: &str) -> bool {
+    let (automataList, decl, _) = xml_parser::parse_xml(PATH);
+    let optimized_components = optimize_components(automataList, &decl);
+    let query = parse_queries::parse(QUERY).unwrap();
+    let q = Query {
+        query: Option::from(query),
+        comment: "".to_string(),
+    };
+
+    let res = create_system_rep_from_query(&q, &optimized_components);
+    let leftSys = res.0;
+    let rightSys = res.1.unwrap();
+    refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap()
+}
+
+pub fn json_refinement_check(PATH: &str, QUERY: &str) -> bool {
+    let (components, decl) = json_setup(String::from(PATH));
+    let query = parse_queries::parse(QUERY).unwrap();
+    let q = Query {
+        query: Option::from(query),
+        comment: "".to_string(),
+    };
+
+    let res = create_system_rep_from_query(&q, &components);
+    let leftSys = res.0;
+    let rightSys = res.1.unwrap();
+    refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap()
 }

--- a/src/tests/refinement/Refinement_delay_add.rs
+++ b/src/tests/refinement/Refinement_delay_add.rs
@@ -1,51 +1,21 @@
 #[cfg(test)]
 mod Refinement_delay_add {
-    use crate::tests::refinement::Helper::setup;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/DelayAdd";
 
     #[test]
     fn A1A2NotRefinesB() {
-        let (automataList, decl) = setup(PATH.to_string());
-        let comp = SystemRepresentation::Composition(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("A1").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("A2").unwrap().clone(),
-            )),
-        );
-        assert!(!refine::check_refinement(
-            comp,
-            SystemRepresentation::Component(automataList.get("B").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: A1 || A2 <= B"));
     }
 
     #[test]
     fn C1NotRefinesC2() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("C1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("C2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: C1 <= C2"));
     }
 
     #[test]
     fn D1NotRefinesD2() {
-        // should fail because outputs are different
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("D1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("D2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: D1 <= D2"));
     }
 }

--- a/src/tests/refinement/Refinement_university.rs
+++ b/src/tests/refinement/Refinement_university.rs
@@ -1,425 +1,247 @@
 #[cfg(test)]
 mod Refinement_university {
-    use crate::tests::refinement::Helper::setup;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/EcdarUniversity";
 
     #[test]
     fn testAdm2RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Adm2").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Adm2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Adm2 <= Adm2"));
     }
 
     #[test]
     fn testHalf1RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("HalfAdm1").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("HalfAdm1").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: HalfAdm1 <= HalfAdm1"
+        ));
     }
 
     #[ignore]
     #[test]
     fn testHalf2RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("HalfAdm2").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("HalfAdm2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: HalfAdm2 <= HalfAdm2"
+        ));
     }
 
     #[test]
     fn testAdmRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Administration <= Administration"
+        ));
     }
 
     #[test]
     fn testMachineRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Machine <= Machine"
+        ));
     }
 
     #[ignore]
     #[test]
     fn testResRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Researcher <= Researcher"
+        ));
     }
 
     #[ignore] // ignore due to infinite loop
     #[test]
     fn testSpecRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: Spec <= Spec"));
     }
 
     #[test]
     fn testMachine3RefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Machine3 <= Machine3"
+        ));
     }
 
     #[test]
     fn testAdmNotRefinesMachine() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Administration <= Machine"
+        ));
     }
 
     #[test]
     fn testAdmNotRefinesResearcher() {
-        //TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Administration <= Researcher"
+        ));
     }
 
     #[test]
     fn testAdmNotRefinesSpec() {
-        //TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Administration <= Spec"
+        ));
     }
 
     #[test]
     fn testAdmNotRefinesMachine3() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Administration <= Machine3"
+        ));
     }
 
     #[test]
     fn testMachineNotRefinesAdm() {
-        //TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Machine <= Administration"
+        ));
     }
 
     #[test]
     fn testMachineNotRefinesResearcher() {
-        //TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Machine <= Researcher"
+        ));
     }
 
     #[test]
     fn testMachineNotRefinesSpec() {
-        //TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Machine <= Spec"));
     }
 
     #[test]
     fn testMachineNotRefinesMachine3() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Machine <= Machine3"
+        ));
     }
 
     #[test]
     fn testResNotRefinesAdm() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Researcher <= Administration"
+        ));
     }
 
     #[test]
     fn testResNotRefinesMachine() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Researcher <= Machine"
+        ));
     }
 
     #[test]
     fn testResNotRefinesSpec() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Researcher <= Spec"
+        ));
     }
 
     #[test]
     fn testResNotRefinesMachine3() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Researcher <= Machine3"
+        ));
     }
 
     #[test]
     fn testSpecNotRefinesAdm() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Spec <= Administration"
+        ));
     }
 
     #[test]
     fn testSpecNotRefinesMachine() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Spec <= Machine"));
     }
 
     #[test]
     fn testSpecNotRefinesResearcher() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Spec <= Researcher"
+        ));
     }
 
     #[test]
     fn testSpecNotRefinesMachine3() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Spec <= Machine3"));
     }
 
     #[test]
     fn testMachine3RefinesMachine() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Machine").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Machine3 <= Machine"
+        ));
     }
 
     #[test]
     fn testMachine3NotRefinesAdm() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Administration").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Machine3 <= Administration"
+        ));
     }
 
     #[test]
     fn testMachine3NotRefinesResearcher() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Researcher").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(
+            PATH,
+            "refinement: Machine3 <= Researcher"
+        ));
     }
 
     #[test]
     fn testMachine3NotRefinesSpec() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Machine3").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(!json_refinement_check(PATH, "refinement: Machine3 <= Spec"));
     }
 
     #[test]
     fn testCompRefinesSpec() {
-        // TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        let comp = SystemRepresentation::Composition(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Administration").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Researcher").unwrap().clone(),
-            )),
-        );
-        assert!(refine::check_refinement(
-            SystemRepresentation::Composition(
-                Box::from(comp),
-                Box::from(SystemRepresentation::Component(
-                    automataList.get("Machine").unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(automataList.get("Spec").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Administration || Researcher || Machine <= Spec"
+        ));
     }
 
     #[test]
     fn testCompRefinesSelf() {
-        // TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        let comp1 = SystemRepresentation::Composition(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Administration").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Machine").unwrap().clone(),
-            )),
-        );
-        let comp2 = SystemRepresentation::Conjunction(
-            Box::from(comp1),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Researcher").unwrap().clone(),
-            )),
-        );
-        let compCopy1 = SystemRepresentation::Composition(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Administration").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Machine").unwrap().clone(),
-            )),
-        );
-        let compCopy2 = SystemRepresentation::Conjunction(
-            Box::from(compCopy1),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("Researcher").unwrap().clone(),
-            )),
-        );
-        assert!(refine::check_refinement(comp2, compCopy2, decl.borrow()).unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement:  Administration || Researcher || Machine <=  Administration || Researcher || Machine"
+        ));
     }
 
     #[test]
     fn testHalf1AndHalf2RefinesAdm2() {
-        // TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        let conj = SystemRepresentation::Conjunction(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("HalfAdm1").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("HalfAdm2").unwrap().clone(),
-            )),
-        );
-        assert!(refine::check_refinement(
-            conj,
-            SystemRepresentation::Component(automataList.get("Adm2").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: HalfAdm1 && HalfAdm2 <= Adm2"
+        ));
     }
 
     #[test]
     fn testAdm2RefinesHalf1AndHalf2() {
-        // TODO This test must succeed, while it fails
-        let (automataList, decl) = setup(PATH.to_string());
-        let conj = SystemRepresentation::Conjunction(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("HalfAdm1").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("HalfAdm2").unwrap().clone(),
-            )),
-        );
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("Adm2").unwrap().clone()),
-            conj,
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(
+            PATH,
+            "refinement: Adm2 <= HalfAdm1 && HalfAdm2"
+        ));
     }
 }

--- a/src/tests/refinement/Refinement_unspec.rs
+++ b/src/tests/refinement/Refinement_unspec.rs
@@ -1,62 +1,27 @@
 #[cfg(test)]
 mod Refinement_unspec {
-    use crate::tests::refinement::Helper::setup;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/Unspec";
 
     #[test]
     fn testARefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("A").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("A").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: A <= A"));
     }
 
     #[test]
     fn testAaRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("AA").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("AA").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: AA <= AA"));
     }
 
     #[test]
     fn testBRefinesSelf() {
-        let (automataList, decl) = setup(PATH.to_string());
-        assert!(refine::check_refinement(
-            SystemRepresentation::Component(automataList.get("B").unwrap().clone()),
-            SystemRepresentation::Component(automataList.get("B").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(json_refinement_check(PATH, "refinement: B <= B"));
     }
 
     #[test]
     fn compNotRefinesB() {
+        assert!(!json_refinement_check(PATH, "refinement: A || AA <= B"));
         // should fail because right side has more inputs
-        let (automataList, decl) = setup(PATH.to_string());
-        let comp = SystemRepresentation::Composition(
-            Box::from(SystemRepresentation::Component(
-                automataList.get("A").unwrap().clone(),
-            )),
-            Box::from(SystemRepresentation::Component(
-                automataList.get("AA").unwrap().clone(),
-            )),
-        );
-        assert!(!refine::check_refinement(
-            comp,
-            SystemRepresentation::Component(automataList.get("B").unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
     }
 }

--- a/src/tests/refinement/xml/conjunction_tests.rs
+++ b/src/tests/refinement/xml/conjunction_tests.rs
@@ -6,12 +6,12 @@ mod conjunction_tests {
 
     #[test]
     fn P0ConjP1RefP2() {
-        assert!(xml_refinement_check(PATH, "refinement: P0 && P1 <= P2"));
+        assert!(!xml_refinement_check(PATH, "refinement: P0 && P1 <= P2"));
     }
 
     #[test]
     fn P3ConjP4CompP5RefP6() {
-        assert!(xml_refinement_check(
+        assert!(!xml_refinement_check(
             PATH,
             "refinement: (P3 && P4) || P5 <= P6"
         ));
@@ -19,7 +19,7 @@ mod conjunction_tests {
 
     #[test]
     fn P7ConjP8ConjP9RefP10() {
-        assert!(xml_refinement_check(
+        assert!(!xml_refinement_check(
             PATH,
             "refinement: P7 && P8 && P9 <= P10"
         ));
@@ -27,6 +27,6 @@ mod conjunction_tests {
 
     #[test]
     fn P11ConjP12RefP13() {
-        assert!(xml_refinement_check(PATH, "refinement: P11 && P12 <= P13"));
+        assert!(!xml_refinement_check(PATH, "refinement: P11 && P12 <= P13"));
     }
 }

--- a/src/tests/refinement/xml/conjunction_tests.rs
+++ b/src/tests/refinement/xml/conjunction_tests.rs
@@ -1,123 +1,32 @@
 #[cfg(test)]
 mod conjunction_tests {
-    use crate::tests::refinement::Helper::optimize_components;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::ModelObjects::xml_parser;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::xml_refinement_check;
 
     static PATH: &str = "samples/xml/conjun.xml";
 
     #[test]
     fn P0ConjP1RefP2() {
-        //passes the test but for wrong reasons ?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-
-        assert_eq!(optimized_components.get(0).unwrap().get_name(), "P0");
-        assert_eq!(optimized_components.get(1).unwrap().get_name(), "P1");
-        assert_eq!(optimized_components.get(2).unwrap().get_name(), "P2");
-
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(1).unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(0).unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(optimized_components.get(2).unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P0 && P1 <= P2"));
     }
 
     #[test]
     fn P3ConjP4CompP5RefP6() {
-        //passes the test but for wrong reasons ?
-        //right side could not match a output from left side o1: ["o", "o1", "o2", "k", "o", "o1", "o2", "k", "go"], o2 ["o", "o1", "o2", "go"]
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-
-        assert_eq!(optimized_components.get(3).unwrap().get_name(), "P3");
-        assert_eq!(optimized_components.get(4).unwrap().get_name(), "P4");
-        assert_eq!(optimized_components.get(5).unwrap().get_name(), "P5");
-        assert_eq!(optimized_components.get(6).unwrap().get_name(), "P6");
-
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Composition(
-                    Box::from(SystemRepresentation::Component(
-                        optimized_components.get(3).unwrap().clone()
-                    )),
-                    Box::from(SystemRepresentation::Component(
-                        optimized_components.get(4).unwrap().clone()
-                    ))
-                )),
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(5).unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(optimized_components.get(6).unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(xml_refinement_check(
+            PATH,
+            "refinement: (P3 && P4) || P5 <= P6"
+        ));
     }
 
     #[test]
     fn P7ConjP8ConjP9RefP10() {
-        //tests fails with weird DBM's, Parsing error ?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-
-        assert_eq!(optimized_components.get(7).unwrap().get_name(), "P7");
-        assert_eq!(optimized_components.get(8).unwrap().get_name(), "P8");
-        assert_eq!(optimized_components.get(9).unwrap().get_name(), "P9");
-        assert_eq!(optimized_components.get(10).unwrap().get_name(), "P10");
-
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Conjunction(
-                    Box::from(SystemRepresentation::Component(
-                        optimized_components.get(7).unwrap().clone()
-                    )),
-                    Box::from(SystemRepresentation::Component(
-                        optimized_components.get(8).unwrap().clone()
-                    ))
-                )),
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(9).unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(optimized_components.get(10).unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(xml_refinement_check(
+            PATH,
+            "refinement: P7 && P8 && P9 <= P10"
+        ));
     }
 
     #[test]
     fn P11ConjP12RefP13() {
-        //passes the test but for wrong reasons ?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-
-        assert_eq!(optimized_components.get(11).unwrap().get_name(), "P11");
-        assert_eq!(optimized_components.get(12).unwrap().get_name(), "P12");
-        assert_eq!(optimized_components.get(13).unwrap().get_name(), "P13");
-
-        assert!(!refine::check_refinement(
-            SystemRepresentation::Conjunction(
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(11).unwrap().clone()
-                )),
-                Box::from(SystemRepresentation::Component(
-                    optimized_components.get(12).unwrap().clone()
-                ))
-            ),
-            SystemRepresentation::Component(optimized_components.get(13).unwrap().clone()),
-            decl.borrow()
-        )
-        .unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P11 && P12 <= P13"));
     }
 }

--- a/src/tests/refinement/xml/delay_refinement.rs
+++ b/src/tests/refinement/xml/delay_refinement.rs
@@ -1,11 +1,6 @@
 #[cfg(test)]
 mod delay_refinement {
-    use crate::tests::refinement::Helper::optimize_components;
-    use crate::ModelObjects::queries::Query;
-    use crate::ModelObjects::{parse_queries, xml_parser};
-    use crate::System::extract_system_rep::create_system_rep_from_query;
-    use crate::System::refine;
-    use std::borrow::Borrow;
+    use crate::tests::refinement::Helper::xml_refinement_check;
 
     static PATH: &str = "samples/xml/delayRefinement.xml";
     static PATH_2: &str = "samples/xml/loop.xml";
@@ -14,1331 +9,421 @@ mod delay_refinement {
     #[ignore] //ignore due to infinite loop
     #[test]
     fn LoopTest() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH_2);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: SelfloopNonZeno <= SelfloopNonZeno").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(
+            PATH_2,
+            "refinement: SelfloopNonZeno <= SelfloopNonZeno"
+        ));
     }
 
     // Self Refinements
     #[test]
     fn T1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T1 <= T1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T1 <= T1"));
     }
 
     #[test]
     fn T2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T2 <= T2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T2 <= T2"));
     }
 
     #[test]
     fn T3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T3 <= T3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T3 <= T3"));
     }
 
     #[test]
     fn C1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: C1 <= C1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: C1 <= C1"));
     }
 
     #[test]
     fn C2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: C2 <= C2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: C2 <= C2"));
     }
 
     #[test]
     fn F1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: F1 <= F1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: F1 <= F1"));
     }
 
     #[test]
     fn F2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: F2 <= F2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: F2 <= F2"));
     }
 
     #[test]
     fn F3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: F3 <= F3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: F3 <= F3"));
     }
 
     #[test]
     fn T4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T4 <= T4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T4 <= T4"));
     }
 
     #[test]
     fn T0RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T0 <= T0").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T0 <= T0"));
     }
 
     #[test]
     fn T5RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T5 <= T5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T5 <= T5"));
     }
 
     #[test]
     fn T6RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T6 <= T6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T6 <= T6"));
     }
 
     #[test]
     fn T7RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T7 <= T7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T7 <= T7"));
     }
 
     #[test]
     fn T8RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T8 <= T8").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T8 <= T8"));
     }
 
     #[test]
     fn T9RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T9 <= T9").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T9 <= T9"));
     }
 
     #[test]
     fn T10RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T10 <= T10").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T10 <= T10"));
     }
 
     #[test]
     fn T11RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T11 <= T11").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T11 <= T11"));
     }
 
     #[test]
     fn N1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: N1 <= N1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: N1 <= N1"));
     }
 
     #[test]
     fn N2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: N2 <= N2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: N2 <= N2"));
     }
 
     #[test]
     fn N3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: N3 <= N3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: N3 <= N3"));
     }
 
     #[test]
     fn N4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: N4 <= N4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: N4 <= N4"));
     }
 
     #[test]
     fn D1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: D1 <= D1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: D1 <= D1"));
     }
 
     #[test]
     fn D2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: D2 <= D2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: D2 <= D2"));
     }
 
     #[test]
     fn K1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K1 <= K1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K1 <= K1"));
     }
 
     #[test]
     fn K2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K2 <= K2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K2 <= K2"));
     }
 
     #[test]
     fn K3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K3 <= K3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K3 <= K3"));
     }
 
     #[test]
     fn K4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K4 <= K4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K4 <= K4"));
     }
 
     #[test]
     fn K5RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K5 <= K5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K5 <= K5"));
     }
 
     #[test]
     fn K6RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K6 <= K6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: K6 <= K6"));
     }
 
     #[test]
     fn P0RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P0 <= P0").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P0 <= P0"));
     }
 
     #[test]
     fn P1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P1 <= P1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P1 <= P1"));
     }
 
     #[test]
     fn P2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P2 <= P2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P2 <= P2"));
     }
 
     #[test]
     fn P3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P3 <= P3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P3 <= P3"));
     }
 
     #[test]
     fn P4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P4 <= P4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P4 <= P4"));
     }
 
     #[test]
     fn P5RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P5 <= P5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P5 <= P5"));
     }
 
     #[test]
     fn P6RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P6 <= P6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P6 <= P6"));
     }
 
     #[test]
     fn P7RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P7 <= P7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P7 <= P7"));
     }
 
     #[test]
     fn L1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L1 <= L1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L1 <= L1"));
     }
 
     #[test]
     fn L2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L2 <= L2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L2 <= L2"));
     }
 
     #[test]
     fn L3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L3 <= L3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L3 <= L3"));
     }
 
     #[test]
     fn L4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L4 <= L4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L4 <= L4"));
     }
 
     #[test]
     fn L5RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L5 <= L5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L5 <= L5"));
     }
 
     #[test]
     fn L6RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L6 <= L6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L6 <= L6"));
     }
 
     #[test]
     fn L7RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L7 <= L7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L7 <= L7"));
     }
 
     #[test]
     fn Z1RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z1 <= Z1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z1 <= Z1"));
     }
 
     #[test]
     fn Z2RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z2 <= Z2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z2 <= Z2"));
     }
 
     #[test]
     fn Z3RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z3 <= Z3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z3 <= Z3"));
     }
 
     #[test]
     fn Z4RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z4 <= Z4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z4 <= Z4"));
     }
 
     #[test]
     fn Z5RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z5 <= Z5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z5 <= Z5"));
     }
 
     #[test]
     fn Z6RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z6 <= Z6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z6 <= Z6"));
     }
 
     #[test]
     fn Z7RefinesSelf() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Z7 <= Z7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z7 <= Z7"));
     }
 
     //     // Rest of the tests
 
     #[test]
     fn T1T2RefinesT3() {
-        //right side could not match a output from left side o1: ["ro", "o", "i", "rand"], o2 ["ro"] - Jecdar pass
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(
-        //     SystemRepresentation::Composition(Box::from(SystemRepresentation::Component(optimized_components.get(0).unwrap().clone())),
-        //                                       Box::from(SystemRepresentation::Component(optimized_components.get(1).unwrap().clone()))),
-        //     SystemRepresentation::Component(optimized_components.get(2).unwrap().clone()),
-        //     decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T1||T2 <= T3"));
     }
 
     #[test]
     fn C1RefinesC2() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: C1 <= C2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: C1 <= C2"));
     }
 
     #[test]
     fn C2RefinesC1() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: C2 <= C1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: C2 <= C1"));
     }
 
     #[test]
     fn T0T1T2RefinesT3() {
-        //right side could not match a output from left side o1: ["dio", "ro", "o", "i", "rand"], o2 ["ro"] - Jecdar pass
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(
-        //     SystemRepresentation::Composition(
-        //         Box::from(SystemRepresentation::Composition(Box::from(SystemRepresentation::Component(optimized_components.get(11).unwrap().clone())),
-        //                                                     Box::from(SystemRepresentation::Component(optimized_components.get(0).unwrap().clone())),)),
-        //         Box::from(SystemRepresentation::Component(optimized_components.get(1).unwrap().clone()))),
-        //     SystemRepresentation::Component(optimized_components.get(2).unwrap().clone()),
-        //     decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T0||T1||T2 <= T3"));
     }
 
     #[test]
     fn F1F2RefinesF3() {
-        //right side could not match a output from left side o1: ["ro", "i", "o", "rand"], o2 ["ro"] - Jecdar pass
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(
-        //     SystemRepresentation::Composition(Box::from(SystemRepresentation::Component(optimized_components.get(7).unwrap().clone())),
-        //                                       Box::from(SystemRepresentation::Component(optimized_components.get(8).unwrap().clone()))),
-        //     SystemRepresentation::Component(optimized_components.get(9).unwrap().clone()),
-        //     decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: F1||F2 <= F3"));
     }
 
     #[test]
     fn T4RefinesT3() {
-        //right side could not match a output from left side o1: ["ro", "go"], o2 ["ro"] - jecdar pass
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(10).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(2).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T4 <= T3"));
     }
 
     #[test]
     fn T6RefinesT5() {
-        //right side could not match a output from left side o1: ["ro", "go"], o2 ["ro"] - jecdar pass
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(13).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(12).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: T6 <= T5"));
     }
 
     #[test]
     fn T7NotRefinesT8() {
         //Refinement passes, tho should fail ! same symbols
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T7 <= T8").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: T7 <= T8"));
     }
 
     #[test]
     fn T9NotRefinesT8() {
         //Refinement passes, tho should fail ! same symbols
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T9 <= T8").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: T9 <= T8"));
     }
 
     #[test]
     fn T10NotRefinesT11() {
         //Refinement passes, tho should fail !
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: T10 <= T11").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: T10 <= T11"));
     }
 
     #[test]
     fn N1RefinesN2() {
-        //right side could not match a output from left side o1: ["o1", "o2"], o2 ["o1"]
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(19).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(20).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: N1 <= N2"));
     }
 
     #[test]
     fn N3NotRefinesN4() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: N3 <= N4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: N3 <= N4"));
     }
 
     #[test]
     fn D2RefinesD1() {
-        // right side could not match a output from left side o1: ["o1", "o2", "o"], o2 ["o1", "o2"]
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(24).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(23).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: D2 <= D1"));
     }
 
     #[test]
     fn D1NotRefinesD2() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: D1 <= D2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: D1 <= D2"));
     }
 
     #[test]
     fn K1NotRefinesK2() {
         //Should fail, but passes ?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K1 <= K2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: K1 <= K2"));
     }
 
     #[test]
     fn K3NotRefinesK4() {
         //should fail, tho passes ?!
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K3 <= K4").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: K3 <= K4"));
     }
 
     #[test]
     fn K5NotRefinesK6() {
         //Should fail, tho passes ?!?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: K5 <= K6").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: K5 <= K6"));
     }
 
     #[test]
     fn P0RefinesP1() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P0 <= P1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P0 <= P1"));
     }
 
     #[test]
     fn P2NotRefinesP3() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P2 <= P3").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: P2 <= P3"));
     }
 
     #[test]
     fn P4RefinesP5() {
-        //right side could not match a output from left side o1: ["o"], o2 [] -- jecdar pass
-        //making o inner output would solve the problem
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(35).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(36).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P4 <= P5"));
     }
 
     #[test]
     fn P6RefinesP7() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: P6 <= P7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: P6 <= P7"));
     }
 
     #[test]
     fn L1L2NotRefinesL3() {
-        //test passes but for wrong reasons ?
-        //right side could not match a output from left side o1: ["o", "ro"], o2 ["ro"]
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(!refine::check_refinement(
-        //     SystemRepresentation::Composition(Box::from(SystemRepresentation::Component(optimized_components.get(39).unwrap().clone())),
-        //                                       Box::from(SystemRepresentation::Component(optimized_components.get(40).unwrap().clone()))),
-        //     SystemRepresentation::Component(optimized_components.get(41).unwrap().clone()),
-        //     decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: L1||L2 <= L3"));
     }
 
     #[test]
     fn L4RefinesL5() {
         //should pass tho fails
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L5 <= L5").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: L5 <= L5"));
     }
 
     #[test]
     fn L6NotRefinesL7() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: L6 <= L7").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: L6 <= L7"));
     }
 
     #[test]
     fn Z1RefinesZ2() {
-        //right side could not match a output from left side o1: ["o", "go"], o2 ["o"]
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(refine::check_refinement(SystemRepresentation::Component(optimized_components.get(46).unwrap().clone()),
-        //                                  SystemRepresentation::Component(optimized_components.get(47).unwrap().clone()),
-        //                                  decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z1 <= Z2"));
     }
 
+    #[ignore]
     #[test]
     fn Z3RefinesZ4() {
-        //TODO: This seem to loop for ever, we need max bounds check!
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let mut optimized_components = optimize_components(automataList, &decl);
-        // let query = parse_queries::parse("refinement: Z3 <= Z4").unwrap();
-        // let q = Query {
-        //     query: Option::from(query),
-        //     comment: "".to_string()
-        // };
-        //
-        // let res = create_system_rep_from_query(&q, &optimized_components);
-        // let leftSys = res.0;
-        // let rightSys = res.1.unwrap();
-        //
-        //
-        // assert!(refine::check_refinement(leftSys,
-        //                                   rightSys,
-        //                                   decl.borrow()).unwrap());
+        assert!(xml_refinement_check(PATH, "refinement: Z3 <= Z4"));
     }
 
     #[test]
     fn Z5Z6NotRefinesZ7() {
-        //right side could not match a output from left side o1: ["i"], o2 []
-        //test passes but for wrong reasons ?
-        // let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        // let optimized_components = optimize_components(automataList, &decl);
-        // assert!(!refine::check_refinement(
-        //     SystemRepresentation::Composition(Box::from(SystemRepresentation::Component(optimized_components.get(50).unwrap().clone())),
-        //                                       Box::from(SystemRepresentation::Component(optimized_components.get(51).unwrap().clone()))),
-        //     SystemRepresentation::Component(optimized_components.get(52).unwrap().clone()),
-        //     decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: Z3 || Z4 <= Z7"));
     }
 
     #[test]
     fn Q1NotRefinesQ2() {
         //refinement should not hold tho it holds ?
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Q1 <= Q2").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: Q1 <= Q2"));
     }
 
     #[test]
     fn Q2NotRefinesQ1() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("refinement: Q2 <= Q1").unwrap();
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        let rightSys = res.1.unwrap();
-
-        assert!(!refine::check_refinement(leftSys, rightSys, decl.borrow()).unwrap());
+        assert!(!xml_refinement_check(PATH, "refinement: Q2 <= Q1"));
     }
 }


### PR DESCRIPTION
Tests were inconsistent sometimes using SystemRepresentations directly and sometimes creating system reps from queries. Now they all generate the reps from the query making them much more readable and ensuring that clock indexes are set correctly (they are only set in create_system_rep_from_query). This fixes the testAdm2RefinesHalf1AndHalf2 test case, but  reveals some new failed tests. 

New failed test cases:
    testMachine3RefinesMachine had an assert false while the java code has assert true.
    P3ConjP4CompP5RefP6 failed for the wrong reasons before.
    D2RefinesD1, F1F2RefinesF3, N1RefinesN2, P4RefinesP5, T0T1T2RefinesT3, T1T2RefinesT3, T4RefinesT3, T6RefinesT5, Z1RefinesZ2 were all commented out before.
