### PR TITLE
Applied right side invariant

### DIFF
--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -267,6 +267,10 @@ fn build_state_pair<'a>(
         return false;
     }
 
+    if !transition2.apply_invariants(locations2, &mut new_sp_zone) {
+        return false;
+    }
+
     new_sp.zone = new_sp_zone;
 
     if is_new_state(&mut new_sp, passed_list) && is_new_state(&mut new_sp, waiting_list) {


### PR DESCRIPTION
Some of the tests were failing because the right hand side invariants were not applied to the zone when using a transition. This allowed for otherwise illegal states to be considered during refinement.