### PR TITLE
Precalculate guards as federations

### DIFF
--- a/dbm/wrapper.cpp
+++ b/dbm/wrapper.cpp
@@ -3,111 +3,128 @@
 #include "dbm/constraints.h"
 #include "dbm/dbm.h"
 
-extern "C" {
-    dbm::fed_t dbm_subtract1_exposed(const raw_t* arg1, const raw_t* arg2, cindex_t dim)
+extern "C"
+{
+    dbm::fed_t dbm_subtract1_exposed(const raw_t *arg1, const raw_t *arg2, cindex_t dim)
     {
         return dbm::fed_t::subtract(arg1, arg2, dim);
     }
 
-    dbm::fed_t dbm_subtract2_exposed(const dbm::dbm_t& arg1, const raw_t* arg2)
+    dbm::fed_t dbm_subtract2_exposed(const dbm::dbm_t &arg1, const raw_t *arg2)
     {
         return dbm::fed_t::subtract(arg1, arg2);
     }
 
-    dbm::fed_t dbm_subtract3_exposed(const dbm::dbm_t& arg1, const dbm::dbm_t& arg2)
+    dbm::fed_t dbm_subtract3_exposed(const dbm::dbm_t &arg1, const dbm::dbm_t &arg2)
     {
         return dbm::fed_t::subtract(arg1, arg2);
     }
 
     int dbm_check_validity(const raw_t *dbm, cindex_t dim)
     {
-        try {
-            if (dbm_isValid(dbm, dim) == BOOL::TRUE) {
+        try
+        {
+            if (dbm_isValid(dbm, dim) == BOOL::TRUE)
+            {
                 return 1;
-            } else {
+            }
+            else
+            {
                 return 0;
             }
-        } catch (...) {
+        }
+        catch (...)
+        {
             return 0;
         }
     }
 
-    void dbm_vec_to_fed( raw_t * dbm[], cindex_t len, cindex_t dim, dbm::fed_t * fed_out)
+    void dbm_vec_to_fed(raw_t *dbm[], cindex_t len, cindex_t dim, dbm::fed_t *fed_out)
     {
         dbm::fed_t fed = (*new dbm::fed_t(dim));
 
-        for (int i = 0; i < len; i++) {
+        for (int i = 0; i < len; i++)
+        {
             fed.add(dbm[i], dim);
         }
         fed_out->add(fed);
     }
 
-    int dbm_get_fed_size(dbm::fed_t * fed){
+    int dbm_get_fed_size(dbm::fed_t *fed)
+    {
         return fed->size();
     }
-    int dbm_get_fed_size_2(dbm::fed_t fed){
+    int dbm_get_fed_size_2(dbm::fed_t fed)
+    {
         return fed.size();
     }
-    int dbm_get_fed_dim(dbm::fed_t * fed) {
+    int dbm_get_fed_dim(dbm::fed_t *fed)
+    {
         return fed->getDimension();
     }
 
-    int dbm_get_dbm_dimension(dbm::fed_t * fed){
+    int dbm_get_dbm_dimension(dbm::fed_t *fed)
+    {
         return (fed->getDimension() * fed->getDimension());
     }
 
-
-    const raw_t * dbm_get_ith_element_in_fed(dbm::fed_t * fed, int element_num){
+    const raw_t *dbm_get_ith_element_in_fed(dbm::fed_t *fed, int element_num)
+    {
         int counter = 0;
-        for (auto i = fed->begin(); i != fed->end(); ++i) {
-            if (counter == element_num) {
+        for (auto i = fed->begin(); i != fed->end(); ++i)
+        {
+            if (counter++ == element_num)
+            {
                 const raw_t *x = i->const_dbm();
                 return x;
             }
         }
     }
 
-
-    void dbm_fed_to_vec( dbm::fed_t &fed, const raw_t *head)
+    void dbm_fed_to_vec(dbm::fed_t &fed, const raw_t *head)
     {
         size_t dimension = fed.getDimension();
         //std::vector<dbm_t> vec;
-        dbm::fdbm_t * prev = NULL;
+        dbm::fdbm_t *prev = NULL;
         int y = 0;
 
         //const raw_t *x = fed.begin()->const_dbm();
         //head = x;
-        for (auto i = fed.begin(); i != fed.end(); ++i) {
+        for (auto i = fed.begin(); i != fed.end(); ++i)
+        {
             const raw_t *x = i->const_dbm();
-            dbm::fdbm_t * next = dbm::fdbm_t::create(x, dimension, prev);
+            dbm::fdbm_t *next = dbm::fdbm_t::create(x, dimension, prev);
             prev = next;
-//
-//
-//
-//            y++;
+            //
+            //
+            //
+            //            y++;
         }
-//
-//
-//        head = prev;
-
+        //
+        //
+        //        head = prev;
     }
 
-    dbm::fdbm_t* dbm_create_fdbm_t() {
-        dbm::fdbm_t * f = NULL;
+    dbm::fdbm_t *dbm_create_fdbm_t()
+    {
+        dbm::fdbm_t *f = NULL;
         return f;
     }
 
     //dbm::fed_t dbm_fed_minus_fed(raw_t * dbm1[], raw_t * dbm2[], cindex_t len1, cindex_t len2, cindex_t dim) {
 
-    void dbm_fed_minus_fed(raw_t * dbm1[], raw_t * dbm2[], cindex_t len1, cindex_t len2, cindex_t dim, dbm::fed_t * fed_out) {
+    void dbm_fed_minus_fed(raw_t *dbm1[], raw_t *dbm2[], cindex_t len1, cindex_t len2, cindex_t dim, dbm::fed_t *fed_out)
+    {
 
         dbm::fed_t fed1 = (*new dbm::fed_t(dim));
-        for (int i = 0; i < len1; i++) {
+        for (int i = 0; i < len1; i++)
+        {
             fed1.add(dbm1[i], dim);
         }
 
         dbm::fed_t fed2 = (*new dbm::fed_t(dim));
-        for (int i = 0; i < len2; i++) {
+        for (int i = 0; i < len2; i++)
+        {
             fed2.add(dbm2[i], dim);
         }
 
@@ -116,8 +133,8 @@ extern "C" {
         fed_out->add(res);
     }
 
-    raw_t dbm_get_value(const raw_t *dbm, cindex_t dim, cindex_t i, cindex_t j) {
-        return dbm[i*dim + j];
+    raw_t dbm_get_value(const raw_t *dbm, cindex_t dim, cindex_t i, cindex_t j)
+    {
+        return dbm[i * dim + j];
     }
 }
-

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -308,4 +308,8 @@ impl Federation {
     pub fn iter_zones(&self) -> impl Iterator<Item = Zone> + '_ {
         self.zones.iter().cloned()
     }
+
+    pub fn iter_mut_zones(&mut self) -> impl Iterator<Item = &mut Zone> + '_ {
+        self.zones.iter_mut()
+    }
 }

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -658,10 +658,6 @@ fn fed_to_federation(fed: &mut dbm_fed_t, dim: u32) -> Federation {
     // zone: [i32; dim * dim]
     let mut zones = Vec::with_capacity(result.len());
     for dbm_ptr in result.iter() {
-        if *dbm_ptr == std::ptr::null() {
-            continue;
-        }
-
         let mut zone_vec = Vec::with_capacity((dim * dim) as usize);
         for i in 0..dim {
             for j in 0..dim {
@@ -736,10 +732,10 @@ pub fn rs_fed_to_vec(fed: &mut dbm_fed_t) -> Vec<*const i32> {
     unsafe {
         let mut result: Vec<*const i32> = vec![];
         let fed_size = dbm_get_fed_size(fed);
+        //println!("Fed size {}", fed_size);
         for i in 0..fed_size {
             let raw_data = dbm_get_ith_element_in_fed(fed, i);
-            let dbm_slice = slice_from_raw_parts(raw_data, dbm_get_dbm_dimension(fed) as usize);
-            let new_const_ptr: *const i32 = (&*dbm_slice).as_ptr();
+            let new_const_ptr: *const i32 = &(*raw_data);
             result.push(new_const_ptr);
         }
 

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::{Federation, Zone};
 use crate::DataReader::parse_edge;
 use crate::DataReader::parse_invariant;
 use crate::EdgeEval::constraint_applyer;
@@ -738,8 +738,8 @@ impl<'a> Transition<'a> {
 
     pub fn apply_invariants(&self, locations: &DecoratedLocationTuple, zone: &mut Zone) -> bool {
         let mut success = true;
-        for (_, _, index) in &self.edges {
-            success = success && locations[*index].apply_invariant(zone);
+        for location in locations {
+            success = success && location.apply_invariant(zone);
         }
         success
     }
@@ -750,6 +750,38 @@ impl<'a> Transition<'a> {
             let next_location = comp.get_location_by_name(new_loc_name);
 
             locations[*index].set_location(next_location);
+        }
+    }
+
+    pub fn get_guard_federation(
+        &self,
+        locations: &DecoratedLocationTuple,
+        dim: u32,
+    ) -> Option<Federation> {
+        let mut fed = Federation::new(vec![Zone::init(dim)], dim);
+        for (comp, edge, index) in &self.edges {
+            let target_location = comp.get_location_by_name(edge.get_target_location());
+            let mut guard_zone = Zone::init(dim);
+            if let Some(inv_source) = target_location.get_invariant() {
+                let dec_loc = DecoratedLocation {
+                    location: target_location,
+                    declarations: locations[*index].declarations.clone(),
+                };
+                dec_loc.apply_invariant(&mut guard_zone);
+            }
+            for clock in edge.get_update_clocks() {
+                let clock_index = comp.get_declarations().get_clock_index_by_name(clock);
+                guard_zone.free_clock(*(clock_index.unwrap()));
+            }
+            edge.apply_guard(&locations[*index], &mut guard_zone);
+            let mut full_fed = Federation::new(vec![Zone::init(dim)], dim);
+            let mut inverse = full_fed.minus_fed(&mut Federation::new(vec![guard_zone], dim));
+            fed = fed.minus_fed(&mut inverse);
+        }
+        if !fed.is_empty() {
+            Some(fed)
+        } else {
+            None
         }
     }
 }

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -756,9 +756,11 @@ impl<'a> Transition<'a> {
 
 impl fmt::Display for Transition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Transition{")?;
         for (_, edge, _) in &self.edges {
-            f.write_fmt(format_args!("{:?}, ", edge))?;
+            f.write_fmt(format_args!("{}, ", edge))?;
         }
+        f.write_str("}")?;
         Ok(())
     }
 }
@@ -777,6 +779,24 @@ pub struct Edge {
     pub update: Option<Vec<parse_edge::Update>>,
     #[serde(deserialize_with = "decode_sync")]
     pub sync: String,
+}
+
+impl fmt::Display for Edge {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "Edge {{{}-({}{})->{}, Guard: {:?}, Update: {:?}}}",
+            self.source_location,
+            self.sync,
+            match self.sync_type {
+                SyncType::Input => "?",
+                SyncType::Output => "!",
+            },
+            self.target_location,
+            self.guard,
+            self.update
+        ))?;
+        Ok(())
+    }
 }
 
 impl Edge {

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -2,8 +2,9 @@ use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::DecoratedLocationTuple;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::representations::SystemRepresentation;
+use std::fmt::{Display, Formatter};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StatePair<'a> {
     pub locations1: DecoratedLocationTuple<'a>,
     pub locations2: DecoratedLocationTuple<'a>,
@@ -80,5 +81,22 @@ impl<'b> StatePair<'b> {
         bounds.add_bounds(&sys2.get_max_bounds(self.zone.dimension));
 
         bounds
+    }
+}
+
+impl<'b> Display for StatePair<'b> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Pair: ({{")?;
+        for l in &self.locations1 {
+            f.write_fmt(format_args!("{}, ", l.get_location().get_id()))?;
+        }
+        f.write_str("}}, {{")?;
+        for l in &self.locations2 {
+            f.write_fmt(format_args!("{}, ", l.get_location().get_id()))?;
+        }
+        f.write_str("}}")?;
+        f.write_fmt(format_args!("Zone: {}", self.zone))?;
+
+        Ok(())
     }
 }

--- a/src/System/extra_actions.rs
+++ b/src/System/extra_actions.rs
@@ -18,6 +18,10 @@ pub fn add_extra_inputs_outputs(
     //let inputs2 = get_extra(&sys2, &sys1, sys_decls, true);
     let outputs2 = get_extra(&sys2, &sys1, sys_decls, false);
 
+    if inputs1.is_empty() && outputs2.is_empty() {
+        return (sys1, sys2, sys_decls.clone());
+    }
+
     let mut new_decl = sys_decls.clone();
     let mut decls = new_decl.get_mut_declarations();
 

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -153,7 +153,6 @@ fn has_valid_state_pair<'a>(
     let mut right_fed = Federation::new(vec![], dim);
     for transition in transitions2 {
         if let Some(mut fed) = transition.get_guard_federation(&states2, dim) {
-            //let mut fed = ;
             for zone in fed.iter_mut_zones() {
                 if zone.intersects(&mut pair_zone) {
                     right_fed.add(zone.clone());

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -187,7 +187,7 @@ fn create_new_state_pairs<'a>(
                 sys2,
                 max_bounds,
                 is_state1,
-            )
+            );
         }
     }
 }
@@ -251,17 +251,12 @@ fn build_state_pair<'a>(
 
     let fed_res = sp_zone_fed.minus_fed(&mut inv_test_fed);
 
-    //let fed_res = invariant_test.dbm_minus_dbm(&mut new_sp_zone);
-
     // Check if the invariant of the other side does not cut solutions and if so, report failure
     // This also happens to be a delay check
     if !fed_res.is_empty() {
         println!("Fed minus fed invalid");
         return false;
     }
-    //if !transition2.apply_invariants(locations2, &mut new_sp_zone) {
-    //    return false;
-    //}
 
     new_sp.zone = new_sp_zone;
     new_sp.zone.extrapolate_max_bounds(max_bounds);

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -45,10 +45,8 @@ pub fn check_refinement(
             let output_transition1 = sys1.collect_next_outputs(curr_pair.get_locations1(), output);
             let output_transition2 = sys2.collect_next_outputs(curr_pair.get_locations2(), output);
 
-            //TODO: Check with alex or thomas to see if this comment is important
-            //If this returns false we should continue after resetting global indexes
-            if !has_valid_state_pair(&output_transition1, &output_transition2, &curr_pair, true)
-                || !create_new_state_pairs(
+            if has_valid_state_pair(&output_transition1, &output_transition2, &curr_pair, true) {
+                create_new_state_pairs(
                     &output_transition1,
                     &output_transition2,
                     &curr_pair,
@@ -59,7 +57,7 @@ pub fn check_refinement(
                     &mut max_bounds,
                     true,
                 )
-            {
+            } else {
                 println!("Refinement check failed for Output {:?}", output);
                 println!("Transitions1:");
                 for t in &output_transition1 {
@@ -83,9 +81,8 @@ pub fn check_refinement(
             let input_transitions1 = sys1.collect_next_inputs(curr_pair.get_locations1(), input);
             let input_transitions2 = sys2.collect_next_inputs(curr_pair.get_locations2(), input);
 
-            //If this returns false we should continue after resetting global indexes
-            if !has_valid_state_pair(&input_transitions2, &input_transitions1, &curr_pair, false)
-                || !create_new_state_pairs(
+            if has_valid_state_pair(&input_transitions2, &input_transitions1, &curr_pair, false) {
+                create_new_state_pairs(
                     &input_transitions2,
                     &input_transitions1,
                     &curr_pair,
@@ -96,7 +93,7 @@ pub fn check_refinement(
                     &mut max_bounds,
                     false,
                 )
-            {
+            } else {
                 println!("Refinement check failed for Input {:?}", input);
                 println!("Transitions1:");
                 for t in &input_transitions1 {
@@ -176,12 +173,11 @@ fn create_new_state_pairs<'a>(
     sys2: &'a SystemRepresentation,
     max_bounds: &mut MaxBounds,
     is_state1: bool,
-) -> bool {
+) {
     for transition1 in transitions1 {
-        let mut found_match = false;
         for transition2 in transitions2 {
             //We currently don't use the bool returned here for anything
-            if build_state_pair(
+            build_state_pair(
                 transition1,
                 transition2,
                 curr_pair,
@@ -191,16 +187,9 @@ fn create_new_state_pairs<'a>(
                 sys2,
                 max_bounds,
                 is_state1,
-            ) {
-                found_match = true;
-            }
-        }
-        if !found_match {
-            //println!("Failed to build state pair");
-            //return false;
+            )
         }
     }
-    true
 }
 
 fn build_state_pair<'a>(


### PR DESCRIPTION
This pr fixes the logic for has_valid_state_pair. Precalculating guards by considering the target invariant and resets and taking an intersection of those zones before comparing between left and right side.

This change fixes all tests except those that assume extra inputs/outputs are not added (AImpNotRefinesAG, ANotRefinesAA, compNotRefinesB, L6NotRefinesL7, N3NotRefinesN4)

It also fixes a bug in the c-wrapper causing null pointers in federations with more than one dbm.