### PR TITLE
Abstract execution of queries

### DIFF
--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -1,0 +1,76 @@
+use crate::ModelObjects::component::Component;
+use crate::ModelObjects::system::UncachedSystem;
+use crate::ModelObjects::system_declarations::SystemDeclarations;
+use crate::System::{extra_actions, refine};
+
+pub enum QueryResult {
+    Refinement(bool),
+    GetComponent(Component),
+    Consistency(bool),
+    Determinism(bool),
+    Error(String),
+}
+
+pub trait ExecutableQuery {
+    fn execute(self: Box<Self>) -> QueryResult;
+}
+
+pub struct RefinementExecutor<'a> {
+    pub sys1: UncachedSystem<'a>,
+    pub sys2: UncachedSystem<'a>,
+    pub decls: SystemDeclarations,
+}
+
+impl<'a> ExecutableQuery for RefinementExecutor<'a> {
+    fn execute(self: Box<Self>) -> QueryResult {
+        let mut extra_components = vec![];
+        let (sys1, sys2, decl) = extra_actions::add_extra_inputs_outputs(
+            self.sys1,
+            self.sys2,
+            &self.decls,
+            &mut extra_components,
+        );
+
+        match refine::check_refinement(sys1, sys2, &decl) {
+            Ok(res) => {
+                println!("Refinement result: {:?}", res);
+                QueryResult::Refinement(res)
+            }
+            Err(err_msg) => QueryResult::Error(err_msg),
+        }
+    }
+}
+
+pub struct GetComponentExecutor<'a> {
+    pub system: UncachedSystem<'a>,
+    pub save_path: String,
+}
+
+impl<'a> ExecutableQuery for GetComponentExecutor<'a> {
+    fn execute(self: Box<Self>) -> QueryResult {
+        // calculate component and serialize it
+        QueryResult::Error(String::from("Not implemented yet"))
+    }
+}
+
+pub struct ConsistencyExecutor<'a> {
+    pub system: UncachedSystem<'a>,
+}
+
+impl<'a> ExecutableQuery for ConsistencyExecutor<'a> {
+    fn execute(self: Box<Self>) -> QueryResult {
+        QueryResult::Consistency(self.system.precheck_sys_rep())
+    }
+}
+
+pub struct DeterminismExecutor<'a> {
+    pub system: UncachedSystem<'a>,
+}
+
+impl<'a> ExecutableQuery for DeterminismExecutor<'a> {
+    fn execute(self: Box<Self>) -> QueryResult {
+        let is_deterministic = self.system.all_components_are_deterministic();
+
+        QueryResult::Determinism(is_deterministic)
+    }
+}

--- a/src/System/mod.rs
+++ b/src/System/mod.rs
@@ -1,3 +1,4 @@
+pub mod executable_query;
 pub mod extra_actions;
 pub mod extract_system_rep;
 pub mod input_enabler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use DataReader::json_reader;
 use ModelObjects::component;
 use ModelObjects::queries;
 use ModelObjects::system_declarations;
+use System::executable_query::{ExecutableQuery, QueryResult};
 
 #[macro_use]
 extern crate pest_derive;
@@ -40,33 +41,16 @@ pub fn main() {
     }
 
     for query in &queries {
-        let (sys1, opt_sys2, check_type) =
-            extract_system_rep::create_system_rep_from_query(query, &optimized_components);
+        let executable_query = Box::new(extract_system_rep::create_executable_query(
+            query,
+            &system_declarations,
+            &optimized_components,
+        ));
 
-        if check_type == "refinement" {
-            let mut extra_components = vec![];
-            let (sys1, sys2, decl) = extra_actions::add_extra_inputs_outputs(
-                sys1,
-                opt_sys2.unwrap(),
-                &system_declarations,
-                &mut extra_components,
-            );
+        let result = executable_query.execute();
 
-            if !checkInputOutput {
-                match refine::check_refinement(sys1, sys2, &decl) {
-                    Ok(res) => println!("Refinement result: {:?}", res),
-                    Err(err_msg) => println!("{}", err_msg),
-                }
-            } else {
-                let inputs2 = sys2.get_input_actions(&system_declarations).clone();
-                let outputs1 = sys1.get_output_actions(&system_declarations).clone();
-
-                let extra_i = sys1.find_matching_input(&system_declarations, &inputs2);
-                let extra_o = sys2.find_matching_output(&system_declarations, &outputs1);
-
-                println!("extra outputs {:?}", extra_o);
-                println!("extra inputs {:?}", extra_i);
-            }
+        if let QueryResult::Error(err) = result {
+            panic!(err);
         }
     }
 }

--- a/src/tests/refinement/xml/consistency_tests.rs
+++ b/src/tests/refinement/xml/consistency_tests.rs
@@ -1,304 +1,237 @@
 #[cfg(test)]
 mod consistency_tests {
-    use crate::tests::refinement::Helper::optimize_components;
-    use crate::DataReader::{parse_queries, xml_parser};
-    use crate::ModelObjects::queries::Query;
-    use crate::ModelObjects::representations::SystemRepresentation;
-    use crate::System::extract_system_rep::create_system_rep_from_query;
+    use crate::tests::refinement::Helper::xml_run_query;
+    use crate::System::executable_query::QueryResult;
 
     static PATH: &str = "samples/xml/ConsTests.xml";
 
     #[test]
     fn testG1() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl); // input enabler samt opsætter clock indcies
-        let query = parse_queries::parse("consistency: G1").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
+        let result = xml_run_query(PATH, "consistency: G1");
 
-        assert!(leftSys.precheck_sys_rep());
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
     #[test]
     fn testG2() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G2").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G2");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG3() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G3").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G3");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG4() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G4").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G4");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG5() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G5").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G5");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG6() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G6").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G6");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG7() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G7").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G7");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG8() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G8").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G8");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG9() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G9").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G9");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG10() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G10").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G10");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG11() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G11").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G11");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG12() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G12").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G12");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG13() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G13").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G13");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG14() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G14").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G14");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG15() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G15").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G15");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG16() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G16").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G16");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG17() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G17").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G17");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG18() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G18").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G18");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG19() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G19").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G19");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(!is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG20() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G20").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G20");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 
     #[test]
     fn testG21() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("consistency: G21").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.precheck_sys_rep());
+        let result = xml_run_query(PATH, "consistency: G21");
+
+        if let QueryResult::Consistency(is_consistent) = result {
+            assert!(is_consistent)
+        } else {
+            panic!("Not consistency check");
+        }
     }
 }

--- a/src/tests/refinement/xml/determinism_tests.rs
+++ b/src/tests/refinement/xml/determinism_tests.rs
@@ -1,293 +1,215 @@
 #[cfg(test)]
 mod determinism_tests {
-    use crate::tests::refinement::Helper::optimize_components;
-    use crate::DataReader::{parse_queries, xml_parser};
-    use crate::ModelObjects::queries::Query;
-    use crate::System::extract_system_rep::create_system_rep_from_query;
+    use crate::tests::refinement::Helper::xml_run_query;
+    use crate::System::executable_query::QueryResult;
 
     static PATH: &str = "samples/xml/ConsTests.xml";
 
     #[test]
     fn testG1() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G1").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G1");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
     #[test]
     fn testG2() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G2").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G2");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG3() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G3").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G3");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
     #[test]
     fn testG4() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G4").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G4");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG5() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G5").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G5");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
     #[test]
     fn testG6() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G6").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G6");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG7() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G7").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G7");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG8() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G8").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G8");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG9() {
         // shouldn't be deterministic
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G9").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G9");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(!is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG10() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G10").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G10");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG11() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G11").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G11");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG12() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G12").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G12");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG13() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G13").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G13");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG14() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G14").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G14");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(!is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG15() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G15").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G15");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG16() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G16").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G16");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(!is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG17() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G17").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G17");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG22() {
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G22").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G22");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 
     #[test]
     fn testG23() {
         // shouldn't be deterministic
-        let (automataList, decl, _) = xml_parser::parse_xml(PATH);
-        let optimized_components = optimize_components(automataList, &decl);
-        let query = parse_queries::parse("determinism: G23").remove(0);
-        let q = Query {
-            query: Option::from(query),
-            comment: "".to_string(),
-        };
+        let result = xml_run_query(PATH, "determinism: G23");
 
-        let res = create_system_rep_from_query(&q, &optimized_components);
-        let leftSys = res.0;
-        assert!(!leftSys.all_components_are_deterministic());
+        if let QueryResult::Determinism(is_deterministic) = result {
+            assert!(!is_deterministic);
+        } else {
+            panic!("Not determinism query");
+        }
     }
 }


### PR DESCRIPTION
This pr moves all execution details about the different queries behind the ExecutionQuery trait which allows queries to be easily executed which returns a QueryResult which can be used to any results.