### PR TITLE
Add global consistency check for systems

### DIFF
--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -169,6 +169,7 @@ impl Zone {
     }
 
     pub fn update(&mut self, var_index: u32, value: i32) {
+        println!("IN c++ land {}", var_index);
         lib::rs_dbm_update(self.matrix.as_mut_slice(), self.dimension, var_index, value)
     }
 

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -169,7 +169,6 @@ impl Zone {
     }
 
     pub fn update(&mut self, var_index: u32, value: i32) {
-        println!("IN c++ land {}", var_index);
         lib::rs_dbm_update(self.matrix.as_mut_slice(), self.dimension, var_index, value)
     }
 
@@ -203,6 +202,10 @@ impl Zone {
 
     pub fn up(&mut self) {
         lib::rs_dbm_up(self.matrix.as_mut_slice(), self.dimension)
+    }
+
+    pub fn down(&mut self) {
+        lib::rs_dbm_down(self.matrix.as_mut_slice(), self.dimension)
     }
 
     pub fn zero(&mut self) {

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -263,6 +263,10 @@ impl Federation {
         Self { zones, dimension }
     }
 
+    pub fn full(dimension: u32) -> Self {
+        Federation::new(vec![Zone::init(dimension)], dimension)
+    }
+
     pub fn minus_fed(&self, other: &Self) -> Federation {
         assert_eq!(self.dimension, other.dimension);
 
@@ -275,6 +279,10 @@ impl Federation {
             .collect();
 
         lib::rs_dbm_fed_minus_fed(&self_zones, &other_zones, self.dimension)
+    }
+
+    pub fn invert(&self) -> Federation {
+        Federation::full(self.dimension).minus_fed(self)
     }
 
     pub fn add(&mut self, zone: Zone) {
@@ -291,5 +299,9 @@ impl Federation {
 
     pub fn iter_mut_zones(&mut self) -> impl Iterator<Item = &mut Zone> + '_ {
         self.zones.iter_mut()
+    }
+
+    pub fn move_zones(self) -> Vec<Zone> {
+        self.zones
     }
 }

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -2,7 +2,7 @@ use crate::DBMLib::lib;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, std::cmp::PartialEq)]
 pub struct Zone {
     pub(crate) dimension: u32,
     pub(in crate::DBMLib) matrix: Vec<i32>,
@@ -223,6 +223,16 @@ impl Zone {
             self.dimension,
             max_bounds.clock_bounds.as_ptr(),
         );
+    }
+
+    pub fn canDelayIndefinitely(&self) -> bool {
+        for i in 1..self.dimension {
+            if !self.is_constraint_infinity(i, 0) {
+                return false;
+            }
+        }
+
+        true
     }
 }
 

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -752,7 +752,6 @@ pub fn rs_dbm_down(dbm: &mut [i32], dimension: u32) {
     }
 }
 
-
 ///setup a slice to be a zero dbm
 pub fn rs_dbm_zero(dbm: &mut [i32], dimension: u32) {
     unsafe {

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -745,6 +745,14 @@ pub fn rs_dbm_up(dbm: &mut [i32], dimension: u32) {
     }
 }
 
+///does a dbm down operation
+pub fn rs_dbm_down(dbm: &mut [i32], dimension: u32) {
+    unsafe {
+        dbm_down(dbm.as_mut_ptr(), dimension);
+    }
+}
+
+
 ///setup a slice to be a zero dbm
 pub fn rs_dbm_zero(dbm: &mut [i32], dimension: u32) {
     unsafe {

--- a/src/DBMLib/lib_stub.rs
+++ b/src/DBMLib/lib_stub.rs
@@ -513,6 +513,11 @@ pub fn rs_dbm_up(_dbm: &mut [i32], _dimension: u32) {
     unimplemented!()
 }
 
+///does a dbm down operation
+pub fn rs_dbm_down(dbm: &mut [i32], dimension: u32) {
+    unimplemented!()
+}
+
 ///setup a slice to be a zero dbm
 pub fn rs_dbm_zero(_dbm: &mut [i32], _dimension: u32) {
     unimplemented!()

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -325,16 +325,17 @@ pub fn apply_constraints_to_state_helper(
 pub fn apply_constraints_to_state2(
     guard: &BoolExpression,
     state: &mut component::State,
+    comp_index: usize,
 ) -> BoolExpression {
     match guard {
         BoolExpression::AndOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state);
+            let left = apply_constraints_to_state2(&**left, state, comp_index);
             if let BoolExpression::Bool(val) = left {
                 if !val {
                     return BoolExpression::Bool(false);
                 }
             }
-            let right = apply_constraints_to_state2(&**right, state);
+            let right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match left {
                 BoolExpression::Bool(left_val) => match right {
@@ -351,8 +352,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::OrOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state);
-            let right = apply_constraints_to_state2(&**right, state);
+            let left = apply_constraints_to_state2(&**left, state, comp_index);
+            let right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match left {
                 BoolExpression::Bool(left_val) => match right {
@@ -367,8 +368,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::LessEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
@@ -400,8 +401,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
@@ -432,8 +433,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::LessT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
@@ -465,8 +466,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
@@ -496,11 +497,19 @@ pub fn apply_constraints_to_state2(
                 }
             }
         }
-        BoolExpression::Parentheses(expr) => apply_constraints_to_state2(expr, state),
+        BoolExpression::Parentheses(expr) => apply_constraints_to_state2(expr, state, comp_index),
         BoolExpression::VarName(name) => {
-            if let Some(clock_index) = state.get_declarations().get_clocks().get(name.as_str()) {
+            if let Some(clock_index) = state
+                .get_declarations(comp_index)
+                .get_clocks()
+                .get(name.as_str())
+            {
                 BoolExpression::Clock(*clock_index)
-            } else if let Some(val) = state.get_declarations().get_ints().get(name.as_str()) {
+            } else if let Some(val) = state
+                .get_declarations(comp_index)
+                .get_ints()
+                .get(name.as_str())
+            {
                 BoolExpression::Int(*val)
             } else {
                 panic!("no variable or clock named {:?}", name)
@@ -511,8 +520,8 @@ pub fn apply_constraints_to_state2(
         BoolExpression::Clock(index) => BoolExpression::Clock(*index),
         //_ => {}
         BoolExpression::EQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -6,7 +6,7 @@ use crate::ModelObjects::representations::BoolExpression;
 /// Used to handle update expressions on edges
 pub fn updater(
     updates: &[parse_edge::Update],
-    state: &mut component::DecoratedLocation,
+    state: &component::DecoratedLocation,
     zone: &mut Zone,
 ) {
     for update in updates {

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -29,12 +29,16 @@ pub fn updater(
 }
 
 /// Used to handle update expressions on edges
-pub fn fullState_updater(updates: &[parse_edge::Update], state: &mut component::State) {
+pub fn state_updater(
+    updates: &[parse_edge::Update],
+    state: &mut component::State,
+    comp_index: usize,
+) {
     for update in updates {
         match update.get_expression() {
             BoolExpression::Int(val) => {
                 if let Some(&clock_index) = state
-                    .get_declarations()
+                    .get_declarations(comp_index)
                     .get_clock_index_by_name(update.get_variable_name())
                 {
                     state.zone.update(clock_index, *val);

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -849,6 +849,14 @@ impl<'a> Transition<'a> {
             Some(updates)
         }
     }
+
+    pub fn get_action(&self) -> Option<&String> {
+        if let Some((_, edge, _)) = self.edges.get(0) {
+            Some(edge.get_sync())
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Display for Transition<'_> {

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -1120,9 +1120,16 @@ impl Declarations {
         self.clocks.len() as u32
     }
 
-    pub fn update_clock_indices(&mut self, start_index: u32) {
+    pub fn set_clock_indices(&mut self, start_index: u32) {
         for (_, v) in self.clocks.iter_mut() {
             *v += start_index
+        }
+    }
+
+    pub fn update_clock_indices(&mut self, start_index: u32, old_offset: u32) {
+        for (_, v) in self.clocks.iter_mut() {
+            *v -= old_offset;
+            *v += start_index;
         }
     }
 

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -364,7 +364,7 @@ impl Component {
         }
         let mut outputExisted: bool = false;
         // If delaying indefinitely is possible -> Prune the rest
-        if prune && ModelObjects::component::Component::canDelayIndefinitely(&currState) {
+        if prune && currState.zone.canDelayIndefinitely() {
             return true;
         } else {
             let mut edges: Vec<&Edge> = vec![];
@@ -434,7 +434,7 @@ impl Component {
                 if outputExisted {
                     return true;
                 }
-                return ModelObjects::component::Component::canDelayIndefinitely(&currState);
+                return currState.zone.canDelayIndefinitely();
             }
             // If by now no locations reached by output edges managed to satisfy independent progress check
             // or there are no output edges from the current location -> Independent progress does not hold
@@ -444,15 +444,6 @@ impl Component {
         }
         // Else if independent progress does not hold through delaying indefinitely,
         // we must check for being able to output and satisfy independent progress
-    }
-    pub fn canDelayIndefinitely(currState: &State) -> bool {
-        for i in 1..currState.zone.dimension {
-            if !currState.zone.is_constraint_infinity(i, 0) {
-                return false;
-            }
-        }
-
-        true
     }
 
     /// method to verify that component is deterministic, remember to verify the clock indices before calling this - check call in refinement.rs for reference
@@ -754,9 +745,9 @@ impl<'a> Transition<'a> {
         out
     }
 
-    pub fn apply_updates(&self, locations: &mut DecoratedLocationTuple, zone: &mut Zone) {
+    pub fn apply_updates(&self, locations: &DecoratedLocationTuple, zone: &mut Zone) {
         for (_, edge, index) in &self.edges {
-            edge.apply_update(&mut locations[*index], zone);
+            edge.apply_update(&locations[*index], zone);
         }
     }
 
@@ -982,7 +973,7 @@ impl fmt::Display for Edge {
 }
 
 impl Edge {
-    pub fn apply_update(&self, location: &mut DecoratedLocation, zone: &mut Zone) {
+    pub fn apply_update(&self, location: &DecoratedLocation, zone: &mut Zone) {
         if let Some(updates) = self.get_update() {
             updater(updates, location, zone);
         }

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -427,7 +427,11 @@ impl Component {
                     .get_invariant()
                 {
                     if let BoolExpression::Bool(false) =
-                        constraint_applyer::apply_constraints_to_state2(source_inv, &mut new_state, 0)
+                        constraint_applyer::apply_constraints_to_state2(
+                            source_inv,
+                            &mut new_state,
+                            0,
+                        )
                     {
                         continue;
                     };
@@ -449,7 +453,7 @@ impl Component {
                     .get_location_by_name(edge.get_target_location())
                     .get_invariant()
                 {
-                    constraint_applyer::apply_constraints_to_state2(target_inv, &mut new_state,0);
+                    constraint_applyer::apply_constraints_to_state2(target_inv, &mut new_state, 0);
                 }
 
                 if !new_state.zone.is_valid() {
@@ -539,7 +543,7 @@ impl Component {
                                 constraint_applyer::apply_constraints_to_state2(
                                     guard,
                                     &mut new_state,
-                                    0
+                                    0,
                                 )
                             {
                             } else {
@@ -662,9 +666,7 @@ fn is_new_state<'a>(state: &mut State<'a>, passed_list: &mut Vec<State<'a>>) -> 
     assert_eq!(state.decorated_locations.len(), 1);
 
     for passed_state_pair in passed_list {
-        if state.get_location(0).get_id()
-            != passed_state_pair.get_location(0).get_id()
-        {
+        if state.get_location(0).get_id() != passed_state_pair.get_location(0).get_id() {
             continue;
         }
         if state.zone.dimension != passed_state_pair.zone.dimension {
@@ -705,30 +707,33 @@ pub struct State<'a> {
 }
 
 impl<'a> State<'a> {
-    pub fn create(decorated_locations: DecoratedLocationTuple<'a>, zone: Zone) -> Self{
-        State{
+    pub fn create(decorated_locations: DecoratedLocationTuple<'a>, zone: Zone) -> Self {
+        State {
             decorated_locations,
             zone,
         }
     }
 
-    pub fn from_location(decorated_locations: DecoratedLocationTuple<'a>, dimensions: u32) -> Option<Self>{
+    pub fn from_location(
+        decorated_locations: DecoratedLocationTuple<'a>,
+        dimensions: u32,
+    ) -> Option<Self> {
         let mut zone = Zone::init(dimensions);
 
         for location in &decorated_locations {
-            if !location.apply_invariant(&mut zone){
+            if !location.apply_invariant(&mut zone) {
                 return None;
             }
         }
 
-        Some(State{
+        Some(State {
             decorated_locations,
             zone,
         })
     }
 
     pub fn is_subset_of(&self, other: &Self) -> bool {
-        if self.decorated_locations != other.decorated_locations{
+        if self.decorated_locations != other.decorated_locations {
             return false;
         }
 
@@ -798,7 +803,7 @@ pub struct Transition<'a> {
     pub edges: Vec<(&'a ComponentView<'a>, &'a Edge, usize)>,
 }
 impl<'a> Transition<'a> {
-    pub fn use_transition(&self, state: &mut State<'a>) -> bool{
+    pub fn use_transition(&self, state: &mut State<'a>) -> bool {
         if self.apply_guards(&state.decorated_locations, &mut state.zone) {
             self.apply_updates(&state.decorated_locations, &mut state.zone);
             self.move_locations(&mut state.decorated_locations);
@@ -811,7 +816,7 @@ impl<'a> Transition<'a> {
         false
     }
 
-    pub fn use_transition_backwards(&self, state: &mut State<'a>) -> bool{
+    pub fn use_transition_backwards(&self, state: &mut State<'a>) -> bool {
         self.apply_updates(&state.decorated_locations, &mut state.zone);
         if self.apply_guards(&state.decorated_locations, &mut state.zone) {
             self.move_locations_backwards(&mut state.decorated_locations);

--- a/src/ModelObjects/component_view.rs
+++ b/src/ModelObjects/component_view.rs
@@ -13,13 +13,23 @@ pub struct ComponentView<'a> {
 impl<'a> ComponentView<'a> {
     pub fn create(component: &'a Component, clock_index_offset: u32) -> Self {
         let mut declarations = component.get_declarations().clone();
-        declarations.update_clock_indices(clock_index_offset);
+        declarations.set_clock_indices(clock_index_offset);
 
         ComponentView {
             component,
             declarations,
             clock_index_offset,
         }
+    }
+
+    pub fn set_clock_offset(&mut self, new_offset: u32) {
+        self.declarations
+            .update_clock_indices(new_offset, self.clock_index_offset);
+        self.clock_index_offset = new_offset;
+    }
+
+    pub fn get_clock_offset(&self) -> u32 {
+        self.clock_index_offset
     }
 
     pub fn get_component(&self) -> &'a Component {

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -558,4 +558,13 @@ impl<'a> SystemRepresentation<'a> {
             comp_view.get_component().check_consistency(true)
         })
     }
+
+    pub fn get_dimensions(&self) -> u32 {
+        let mut dimensions = 1;
+        self.all_components(&mut |comp_view| {
+            dimensions += comp_view.clock_count();
+            true
+        });
+        dimensions
+    }
 }

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -321,6 +321,22 @@ impl<'a> SystemRepresentation<'a> {
         }
     }
 
+    pub fn all_mut_components<'b, F>(&'b mut self, predicate: &mut F) -> bool
+    where
+        F: FnMut(&'b mut ComponentView<'a>) -> bool,
+    {
+        match self {
+            SystemRepresentation::Composition(left_side, right_side) => {
+                left_side.all_mut_components(predicate) && right_side.all_mut_components(predicate)
+            }
+            SystemRepresentation::Conjunction(left_side, right_side) => {
+                left_side.all_mut_components(predicate) && right_side.all_mut_components(predicate)
+            }
+            SystemRepresentation::Parentheses(rep) => rep.all_mut_components(predicate),
+            SystemRepresentation::Component(comp_view) => predicate(comp_view),
+        }
+    }
+
     pub fn collect_next_transitions<'b>(
         &'b self,
         locations: &[DecoratedLocation<'a>],

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -28,50 +28,48 @@ impl BoolExpression {
     pub fn contains_max_bound(&self) -> bool {
         match self {
             BoolExpression::AndOp(left, right) => {
-                left.contains_max_bound() ||
-                right.contains_max_bound()
+                left.contains_max_bound() || right.contains_max_bound()
             }
             BoolExpression::OrOp(left, right) => {
-                left.contains_max_bound() ||
-                right.contains_max_bound()
+                left.contains_max_bound() || right.contains_max_bound()
             }
             BoolExpression::Parentheses(expr) => expr.contains_max_bound(),
             BoolExpression::GreatEQ(left, right) => {
-                if let BoolExpression::Clock(_) = right.as_ref(){
+                if let BoolExpression::Clock(_) = right.as_ref() {
                     true
-                }else if let BoolExpression::VarName(_) = right.as_ref(){
+                } else if let BoolExpression::VarName(_) = right.as_ref() {
                     true
-                }else{
+                } else {
                     false
                 }
-            },
+            }
             BoolExpression::LessEQ(left, right) => {
-                if let BoolExpression::Clock(_) = left.as_ref(){
+                if let BoolExpression::Clock(_) = left.as_ref() {
                     true
-                }else if let BoolExpression::VarName(_) = left.as_ref(){
+                } else if let BoolExpression::VarName(_) = left.as_ref() {
                     true
-                }else{
+                } else {
                     false
                 }
-            },
+            }
             BoolExpression::LessT(left, right) => {
-                if let BoolExpression::Clock(_) = left.as_ref(){
+                if let BoolExpression::Clock(_) = left.as_ref() {
                     true
-                }else if let BoolExpression::VarName(_) = left.as_ref(){
+                } else if let BoolExpression::VarName(_) = left.as_ref() {
                     true
-                }else{
+                } else {
                     false
                 }
-            },
+            }
             BoolExpression::GreatT(left, right) => {
-                if let BoolExpression::Clock(_) = right.as_ref(){
+                if let BoolExpression::Clock(_) = right.as_ref() {
                     true
-                }else if let BoolExpression::VarName(_) = right.as_ref(){
+                } else if let BoolExpression::VarName(_) = right.as_ref() {
                     true
-                }else{
+                } else {
                     false
                 }
-            },
+            }
             _ => false,
         }
     }

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -66,8 +66,11 @@ pub struct ConsistencyExecutor<'a> {
 }
 
 impl<'a> ExecutableQuery for ConsistencyExecutor<'a> {
-    fn execute(self: Box<Self>) -> QueryResult {
-        QueryResult::Consistency(self.system.check_consistency(&self.as_ref().sys_decls))
+    fn execute(mut self: Box<Self>) -> QueryResult {
+        QueryResult::Consistency(
+            self.system
+                .check_consistency(&self.as_ref().sys_decls.clone()),
+        )
     }
 }
 

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -3,6 +3,7 @@ use crate::ModelObjects::component::Component;
 use crate::ModelObjects::system::UncachedSystem;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
 use crate::System::save_component::combine_components;
+use crate::System::consistency::consistency_check;
 use crate::System::{extra_actions, refine};
 
 pub enum QueryResult {
@@ -68,8 +69,7 @@ pub struct ConsistencyExecutor<'a> {
 impl<'a> ExecutableQuery for ConsistencyExecutor<'a> {
     fn execute(mut self: Box<Self>) -> QueryResult {
         QueryResult::Consistency(
-            self.system
-                .check_consistency(&self.as_ref().sys_decls.clone()),
+            consistency_check(&mut self.system, &self.sys_decls)
         )
     }
 }

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -62,11 +62,12 @@ impl<'a> ExecutableQuery for GetComponentExecutor<'a> {
 
 pub struct ConsistencyExecutor<'a> {
     pub system: UncachedSystem<'a>,
+    pub sys_decls: SystemDeclarations,
 }
 
 impl<'a> ExecutableQuery for ConsistencyExecutor<'a> {
     fn execute(self: Box<Self>) -> QueryResult {
-        QueryResult::Consistency(self.system.precheck_sys_rep())
+        QueryResult::Consistency(self.system.check_consistency(&self.as_ref().sys_decls))
     }
 }
 

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -2,8 +2,8 @@ use crate::DataReader::json_writer::component_to_json;
 use crate::ModelObjects::component::Component;
 use crate::ModelObjects::system::UncachedSystem;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
-use crate::System::save_component::combine_components;
 use crate::System::consistency::consistency_check;
+use crate::System::save_component::combine_components;
 use crate::System::{extra_actions, refine};
 
 pub enum QueryResult {
@@ -68,9 +68,7 @@ pub struct ConsistencyExecutor<'a> {
 
 impl<'a> ExecutableQuery for ConsistencyExecutor<'a> {
     fn execute(mut self: Box<Self>) -> QueryResult {
-        QueryResult::Consistency(
-            consistency_check(&mut self.system, &self.sys_decls)
-        )
+        QueryResult::Consistency(consistency_check(&mut self.system, &self.sys_decls))
     }
 }
 

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -36,6 +36,7 @@ pub fn create_executable_query<'a>(
                     components,
                     &mut clock_index,
                 )),
+                sys_decls: system_declarations.clone()
             }),
             QueryExpression::Determinism(query_expression) => Box::new(DeterminismExecutor {
                 system: UncachedSystem::create(extract_side(

--- a/src/System/global_consistency.rs
+++ b/src/System/global_consistency.rs
@@ -1,0 +1,122 @@
+use crate::ModelObjects::representations::SystemRepresentation;
+use crate::ModelObjects::system::UncachedSystem;
+use crate::ModelObjects::component::{Component, Edge, State, DecoratedLocation};
+use crate::DBMLib::dbm::Zone;
+use crate::ModelObjects::system_declarations::SystemDeclarations;
+
+pub fn consistency_check(system: &mut UncachedSystem, sys_decls: &SystemDeclarations) -> bool {
+    if let SystemRepresentation::Composition(_, _) = system.borrow_representation(){
+        check_consistency_repr(system.borrow_representation(), sys_decls)
+    }else{
+        let old_offset = system.set_clock_offset(0);
+
+        let faulty_states = find_inconsistent_states(system, sys_decls);
+        let result = reachability_analysis(system, sys_decls, faulty_states);
+
+        system.set_clock_offset(old_offset);
+
+        result
+    }
+}
+
+fn check_consistency_repr(system_repr: &SystemRepresentation, sys_decls: &SystemDeclarations) -> bool {
+    //Apply optimisation: If A and B are consistent in system  A || B = C then C is also consistent
+    if let SystemRepresentation::Composition(left, right) = system_repr {
+        check_consistency_repr(left.as_ref(), sys_decls) &&
+        check_consistency_repr(right.as_ref(), sys_decls)
+    }else{
+        let mut system = UncachedSystem::create(system_repr.clone());
+        system.set_clock_offset(0);
+        
+        let faulty_states = find_inconsistent_states(&system, sys_decls);
+        reachability_analysis(&system, sys_decls, faulty_states)
+    }
+}
+
+fn find_inconsistent_states<'a>(system: &'a UncachedSystem, sys_decls: &SystemDeclarations) -> Vec<State<'a>> {
+    let mut inconsistent_states = vec![];
+    let dimensions = system.borrow_representation().get_dimensions();
+
+    
+    'location_for: for location in system.get_locations() {
+        let mut zone = Zone::init(dimensions);
+        
+        for comp_loc in &location {
+            if !comp_loc.apply_invariant(&mut zone){
+                continue 'location_for; //Skip invalid zones
+            }
+        }
+        
+        let state = State{
+            decorated_locations: location,
+            zone,
+        };
+        
+        let cannot_delay_forever = !state.zone.canDelayIndefinitely();
+        let no_open_output = system.collect_open_output_transitions(sys_decls, &state).is_empty();
+        
+        if no_open_output && cannot_delay_forever {
+            inconsistent_states.push(state);
+        }
+    }
+    
+    inconsistent_states
+}
+
+fn reachability_analysis<'a>(system: &'a UncachedSystem, sys_decls: &SystemDeclarations, mut faulty_states: Vec<State<'a>>) -> bool {
+    let dimensions = system.borrow_representation().get_dimensions();
+    let max_bounds = system.get_max_bounds(dimensions);
+    println!("There are {} initially bad states", faulty_states.len());
+    
+    let start_state = State::from_location(system.get_initial_locations(), dimensions).unwrap();
+    
+    let mut index = 0;
+    while index < faulty_states.len() {
+        let state = faulty_states[index].clone();
+        index += 1;
+        
+        println!("{}", state.zone);
+
+        //If we can reach the error state from the initial state we fail the consistency check
+        if start_state.is_subset_of(&state){
+            return false;
+        }
+
+        let inputs = system.collect_previous_inputs(sys_decls, &state);
+
+        
+        'input_for: for input in &inputs {
+            //Apply the transition backwards and move from state to previous_state
+            let mut previous_state = state.clone();
+            input.apply_updates(&previous_state.decorated_locations, &mut previous_state.zone);
+            if input.apply_guards(&previous_state.decorated_locations, &mut previous_state.zone) {
+                input.move_locations_backwards(&mut previous_state.decorated_locations);
+                if input.apply_invariants(&mut previous_state.decorated_locations, &mut previous_state.zone) {
+                    //Ignore invalid states
+                    continue;
+                }
+            }
+
+            //check if strengthend (Guard or invariant)?! can exclude transition
+
+
+
+            //If previous_state has already been deemed faulty skip this transition
+            for faulty_state in &faulty_states {
+                if previous_state.is_subset_of(faulty_state) {
+                    continue 'input_for;
+                }
+            }
+            
+            //If this is a new faulty state, expand the state's zone to include all times that can reach this fault
+            previous_state.zone.down();
+            if !input.apply_invariants(&mut previous_state.decorated_locations, &mut previous_state.zone) {
+                panic!("This should never fail as we already checked for earlier");
+            }
+            previous_state.zone.extrapolate_max_bounds(&max_bounds);
+            faulty_states.push(previous_state);
+        }
+    }
+
+    true
+}

--- a/src/System/global_consistency.rs
+++ b/src/System/global_consistency.rs
@@ -1,13 +1,13 @@
+use crate::DBMLib::dbm::Zone;
+use crate::ModelObjects::component::{Component, DecoratedLocation, Edge, State};
 use crate::ModelObjects::representations::SystemRepresentation;
 use crate::ModelObjects::system::UncachedSystem;
-use crate::ModelObjects::component::{Component, Edge, State, DecoratedLocation};
-use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
 
 pub fn consistency_check(system: &mut UncachedSystem, sys_decls: &SystemDeclarations) -> bool {
-    if let SystemRepresentation::Composition(_, _) = system.borrow_representation(){
+    if let SystemRepresentation::Composition(_, _) = system.borrow_representation() {
         check_consistency_repr(system.borrow_representation(), sys_decls)
-    }else{
+    } else {
         let old_offset = system.set_clock_offset(0);
 
         let faulty_states = find_inconsistent_states(system, sys_decls);
@@ -19,79 +19,98 @@ pub fn consistency_check(system: &mut UncachedSystem, sys_decls: &SystemDeclarat
     }
 }
 
-fn check_consistency_repr(system_repr: &SystemRepresentation, sys_decls: &SystemDeclarations) -> bool {
+fn check_consistency_repr(
+    system_repr: &SystemRepresentation,
+    sys_decls: &SystemDeclarations,
+) -> bool {
     //Apply optimisation: If A and B are consistent in system  A || B = C then C is also consistent
     if let SystemRepresentation::Composition(left, right) = system_repr {
-        check_consistency_repr(left.as_ref(), sys_decls) &&
-        check_consistency_repr(right.as_ref(), sys_decls)
-    }else{
+        check_consistency_repr(left.as_ref(), sys_decls)
+            && check_consistency_repr(right.as_ref(), sys_decls)
+    } else {
         let mut system = UncachedSystem::create(system_repr.clone());
         system.set_clock_offset(0);
-        
+
         let faulty_states = find_inconsistent_states(&system, sys_decls);
         reachability_analysis(&system, sys_decls, faulty_states)
     }
 }
 
-fn find_inconsistent_states<'a>(system: &'a UncachedSystem, sys_decls: &SystemDeclarations) -> Vec<State<'a>> {
+fn find_inconsistent_states<'a>(
+    system: &'a UncachedSystem,
+    sys_decls: &SystemDeclarations,
+) -> Vec<State<'a>> {
     let mut inconsistent_states = vec![];
     let dimensions = system.borrow_representation().get_dimensions();
 
-    
     'location_for: for location in system.get_locations() {
         let mut zone = Zone::init(dimensions);
-        
+
         for comp_loc in &location {
-            if !comp_loc.apply_invariant(&mut zone){
+            if !comp_loc.apply_invariant(&mut zone) {
                 continue 'location_for; //Skip invalid zones
             }
         }
-        
-        let state = State{
+
+        let state = State {
             decorated_locations: location,
             zone,
         };
-        
+
         let cannot_delay_forever = !state.zone.canDelayIndefinitely();
-        let no_open_output = system.collect_open_output_transitions(sys_decls, &state).is_empty();
-        
+        let no_open_output = system
+            .collect_open_output_transitions(sys_decls, &state)
+            .is_empty();
+
         if no_open_output && cannot_delay_forever {
             inconsistent_states.push(state);
         }
     }
-    
+
     inconsistent_states
 }
 
-fn reachability_analysis<'a>(system: &'a UncachedSystem, sys_decls: &SystemDeclarations, mut faulty_states: Vec<State<'a>>) -> bool {
+fn reachability_analysis<'a>(
+    system: &'a UncachedSystem,
+    sys_decls: &SystemDeclarations,
+    mut faulty_states: Vec<State<'a>>,
+) -> bool {
     let dimensions = system.borrow_representation().get_dimensions();
     let max_bounds = system.get_max_bounds(dimensions);
     println!("There are {} initially bad states", faulty_states.len());
-    
+
     let start_state = State::from_location(system.get_initial_locations(), dimensions).unwrap();
-    
+
     let mut index = 0;
     while index < faulty_states.len() {
         let state = faulty_states[index].clone();
         index += 1;
-        
+
         println!("{}", state.zone);
 
         //If we can reach the error state from the initial state we fail the consistency check
-        if start_state.is_subset_of(&state){
+        if start_state.is_subset_of(&state) {
             return false;
         }
 
         let inputs = system.collect_previous_inputs(sys_decls, &state);
 
-        
         'input_for: for input in &inputs {
             //Apply the transition backwards and move from state to previous_state
             let mut previous_state = state.clone();
-            input.apply_updates(&previous_state.decorated_locations, &mut previous_state.zone);
-            if input.apply_guards(&previous_state.decorated_locations, &mut previous_state.zone) {
+            input.apply_updates(
+                &previous_state.decorated_locations,
+                &mut previous_state.zone,
+            );
+            if input.apply_guards(
+                &previous_state.decorated_locations,
+                &mut previous_state.zone,
+            ) {
                 input.move_locations_backwards(&mut previous_state.decorated_locations);
-                if input.apply_invariants(&mut previous_state.decorated_locations, &mut previous_state.zone) {
+                if input.apply_invariants(
+                    &mut previous_state.decorated_locations,
+                    &mut previous_state.zone,
+                ) {
                     //Ignore invalid states
                     continue;
                 }
@@ -99,18 +118,19 @@ fn reachability_analysis<'a>(system: &'a UncachedSystem, sys_decls: &SystemDecla
 
             //check if strengthend (Guard or invariant)?! can exclude transition
 
-
-
             //If previous_state has already been deemed faulty skip this transition
             for faulty_state in &faulty_states {
                 if previous_state.is_subset_of(faulty_state) {
                     continue 'input_for;
                 }
             }
-            
+
             //If this is a new faulty state, expand the state's zone to include all times that can reach this fault
             previous_state.zone.down();
-            if !input.apply_invariants(&mut previous_state.decorated_locations, &mut previous_state.zone) {
+            if !input.apply_invariants(
+                &mut previous_state.decorated_locations,
+                &mut previous_state.zone,
+            ) {
                 panic!("This should never fail as we already checked for earlier");
             }
             previous_state.zone.extrapolate_max_bounds(&max_bounds);

--- a/src/System/mod.rs
+++ b/src/System/mod.rs
@@ -1,7 +1,7 @@
 pub mod executable_query;
 pub mod extra_actions;
 pub mod extract_system_rep;
+pub mod global_consistency;
 pub mod input_enabler;
 pub mod refine;
 pub mod save_component;
-pub mod global_consistency;

--- a/src/System/mod.rs
+++ b/src/System/mod.rs
@@ -4,3 +4,4 @@ pub mod extract_system_rep;
 pub mod input_enabler;
 pub mod refine;
 pub mod save_component;
+pub mod global_consistency;

--- a/src/tests/consistency/composition.rs
+++ b/src/tests/consistency/composition.rs
@@ -1,0 +1,1199 @@
+#[cfg(test)]
+mod composition_tests {
+    use crate::tests::refinement::Helper::json_run_query;
+    use crate::System::executable_query::QueryResult;
+
+    static PATH: &str = "samples/json/Conjunction";
+    static ECDAR_UNI: &str = "samples/json/EcdarUniversity";
+
+    #[test]
+    fn Test1Test1IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test1") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test2") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test3") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test4") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test5") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test1Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test2") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test3") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test4") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test5") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test2Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test3") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test4") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test5") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test3Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test4") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test5") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test4Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test5") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test5Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test6") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test6Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test7") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test7Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test8Test8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8||Test8") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test8Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test8Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test8Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test8Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test9Test9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9||Test9") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test9Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test9Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test9Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test10Test10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10||Test10") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test10Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test10Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test11Test11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11||Test11") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test11Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Test12Test12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test12||Test12") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2Adm2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2||Adm2") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2AdministrationIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||Administration")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2HalfAdm1IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||HalfAdm1")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2HalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||HalfAdm2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2MachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||Machine")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2Machine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2Machine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2ResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Adm2SpecIsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2||Spec") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationAdministrationIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Administration")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationHalfAdm1IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||HalfAdm1")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationHalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||HalfAdm2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Machine")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn AdministrationSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1HalfAdm1IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||HalfAdm1")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1HalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||HalfAdm2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1MachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||Machine")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1Machine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1Machine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1ResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1SpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2HalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||HalfAdm2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2MachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||Machine")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2Machine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2Machine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2ResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2SpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn MachineMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine||Machine")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn MachineMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn MachineMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn MachineResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn MachineSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine2Machine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2||Machine2")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine2Machine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine2ResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine2SpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine3Machine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3||Machine3")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine3ResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn Machine3SpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn ResearcherResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Researcher||Researcher")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn ResearcherSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Researcher||Spec")
+        {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    fn SpecSpecIsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Spec||Spec") {
+            assert!(res)
+        } else {
+            assert!(false)
+        }
+    }
+}

--- a/src/tests/consistency/conjunction.rs
+++ b/src/tests/consistency/conjunction.rs
@@ -1,0 +1,956 @@
+#[cfg(test)]
+mod Conjunction_tests {
+    use crate::tests::refinement::Helper::json_run_query;
+    use crate::System::executable_query::QueryResult;
+
+    static PATH: &str = "samples/json/Conjunction";
+    static ECDAR_UNI: &str = "samples/json/EcdarUniversity";
+
+    #[test]
+    fn Adm2AndAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2 && Adm2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndAdministrationIsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && Administration")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndHalfAdm1IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && HalfAdm1")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndHalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && HalfAdm2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Adm2 && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Adm2AndSpecIsNotConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2 && Spec")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndAdministrationIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Administration")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndHalfAdm1IsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && HalfAdm1")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndHalfAdm2IsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && HalfAdm2")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Machine")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn AdministrationAndSpecIsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Administration && Spec")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndHalfAdm1IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && HalfAdm1")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndHalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && HalfAdm2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm1AndSpecIsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Spec")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndHalfAdm2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && HalfAdm2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn HalfAdm2AndSpecIsNotConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Spec")
+        {
+            assert!(!res)
+        }
+    }
+
+    #[test]
+    fn MachineAndMachineIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine && Machine")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn MachineAndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn MachineAndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn MachineAndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn MachineAndSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine && Spec")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine2AndMachine2IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2 && Machine2")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine2AndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2 && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine2AndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2 && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine2AndSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine2 && Spec")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine3AndMachine3IsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3 && Machine3")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine3AndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3 && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Machine3AndSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Machine3 && Spec")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn ResearcherAndResearcherIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Researcher && Researcher")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn ResearcherAndSpecIsConsistent() {
+        if let QueryResult::Consistency(res) =
+            json_run_query(ECDAR_UNI, "consistency:Researcher && Spec")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn SpecAndSpecIsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Spec && Spec")
+        {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest1IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test1") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test2") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test3") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test4") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test5") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test1AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest2IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test2") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test3") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test4") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test5") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test2AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest3IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test3") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test4") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test5") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test3AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest4IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test4") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test5") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test4AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest5IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test5") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test5AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest6IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test6") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test6AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest7IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test7") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test7AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test8AndTest8IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test8") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test8AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test8AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test8AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test8AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test9AndTest9IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test9") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test9AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test9AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test9AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test10AndTest10IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test10") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test10AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test10AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test11AndTest11IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11&&Test11") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test11AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11&&Test12") {
+            assert!(res)
+        }
+    }
+
+    #[test]
+    fn Test12AndTest12IsConsistent() {
+        if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test12&&Test12") {
+            assert!(res)
+        }
+    }
+}

--- a/src/tests/consistency/conjunction.rs
+++ b/src/tests/consistency/conjunction.rs
@@ -11,6 +11,8 @@ mod Conjunction_tests {
         if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2 && Adm2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -20,6 +22,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && Administration")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -29,6 +33,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && HalfAdm1")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -38,6 +44,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && HalfAdm2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -47,6 +55,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -56,6 +66,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -65,6 +77,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -74,6 +88,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Adm2 && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -82,6 +98,8 @@ mod Conjunction_tests {
         if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Adm2 && Spec")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -91,6 +109,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Administration")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -100,6 +120,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && HalfAdm1")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -109,6 +131,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && HalfAdm2")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -118,6 +142,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Machine")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -127,6 +153,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -136,6 +164,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -145,6 +175,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -154,6 +186,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Administration && Spec")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -163,6 +197,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && HalfAdm1")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -172,6 +208,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && HalfAdm2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -181,6 +219,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -190,6 +230,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -199,6 +241,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -208,6 +252,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -217,6 +263,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm1 && Spec")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -226,6 +274,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && HalfAdm2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -235,6 +285,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -244,6 +296,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -253,6 +307,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -262,6 +318,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -271,6 +329,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:HalfAdm2 && Spec")
         {
             assert!(!res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -280,6 +340,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine && Machine")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -289,6 +351,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -298,6 +362,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -307,6 +373,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -316,6 +384,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine && Spec")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -325,6 +395,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine2 && Machine2")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -334,6 +406,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine2 && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -343,6 +417,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine2 && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -352,6 +428,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine2 && Spec")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -361,6 +439,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine3 && Machine3")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -370,6 +450,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine3 && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -379,6 +461,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Machine3 && Spec")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -388,6 +472,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Researcher && Researcher")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -397,6 +483,8 @@ mod Conjunction_tests {
             json_run_query(ECDAR_UNI, "consistency:Researcher && Spec")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -405,6 +493,8 @@ mod Conjunction_tests {
         if let QueryResult::Consistency(res) = json_run_query(ECDAR_UNI, "consistency:Spec && Spec")
         {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -412,6 +502,8 @@ mod Conjunction_tests {
     fn Test1AndTest1IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test1") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -419,6 +511,8 @@ mod Conjunction_tests {
     fn Test1AndTest2IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test2") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -426,6 +520,8 @@ mod Conjunction_tests {
     fn Test1AndTest3IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test3") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -433,6 +529,8 @@ mod Conjunction_tests {
     fn Test1AndTest4IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test4") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -440,6 +538,8 @@ mod Conjunction_tests {
     fn Test1AndTest5IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test5") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -447,6 +547,8 @@ mod Conjunction_tests {
     fn Test1AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -454,6 +556,8 @@ mod Conjunction_tests {
     fn Test1AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -461,6 +565,8 @@ mod Conjunction_tests {
     fn Test1AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -468,6 +574,8 @@ mod Conjunction_tests {
     fn Test1AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -475,6 +583,8 @@ mod Conjunction_tests {
     fn Test1AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -482,6 +592,8 @@ mod Conjunction_tests {
     fn Test1AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -489,6 +601,8 @@ mod Conjunction_tests {
     fn Test1AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test1&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -496,6 +610,8 @@ mod Conjunction_tests {
     fn Test2AndTest2IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test2") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -503,6 +619,8 @@ mod Conjunction_tests {
     fn Test2AndTest3IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test3") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -510,6 +628,8 @@ mod Conjunction_tests {
     fn Test2AndTest4IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test4") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -517,6 +637,8 @@ mod Conjunction_tests {
     fn Test2AndTest5IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test5") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -524,6 +646,8 @@ mod Conjunction_tests {
     fn Test2AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -531,6 +655,8 @@ mod Conjunction_tests {
     fn Test2AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -538,6 +664,8 @@ mod Conjunction_tests {
     fn Test2AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -545,6 +673,8 @@ mod Conjunction_tests {
     fn Test2AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -552,6 +682,8 @@ mod Conjunction_tests {
     fn Test2AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -559,6 +691,8 @@ mod Conjunction_tests {
     fn Test2AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -566,6 +700,8 @@ mod Conjunction_tests {
     fn Test2AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test2&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -573,6 +709,8 @@ mod Conjunction_tests {
     fn Test3AndTest3IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test3") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -580,6 +718,8 @@ mod Conjunction_tests {
     fn Test3AndTest4IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test4") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -587,6 +727,8 @@ mod Conjunction_tests {
     fn Test3AndTest5IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test5") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -594,6 +736,8 @@ mod Conjunction_tests {
     fn Test3AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -601,6 +745,8 @@ mod Conjunction_tests {
     fn Test3AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -608,6 +754,8 @@ mod Conjunction_tests {
     fn Test3AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -615,6 +763,8 @@ mod Conjunction_tests {
     fn Test3AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -622,6 +772,8 @@ mod Conjunction_tests {
     fn Test3AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -629,6 +781,8 @@ mod Conjunction_tests {
     fn Test3AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -636,6 +790,8 @@ mod Conjunction_tests {
     fn Test3AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test3&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -643,6 +799,8 @@ mod Conjunction_tests {
     fn Test4AndTest4IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test4") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -650,6 +808,8 @@ mod Conjunction_tests {
     fn Test4AndTest5IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test5") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -657,6 +817,8 @@ mod Conjunction_tests {
     fn Test4AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -664,6 +826,8 @@ mod Conjunction_tests {
     fn Test4AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -671,6 +835,8 @@ mod Conjunction_tests {
     fn Test4AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -678,6 +844,8 @@ mod Conjunction_tests {
     fn Test4AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -685,6 +853,8 @@ mod Conjunction_tests {
     fn Test4AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -692,6 +862,8 @@ mod Conjunction_tests {
     fn Test4AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -699,6 +871,8 @@ mod Conjunction_tests {
     fn Test4AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test4&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -706,6 +880,8 @@ mod Conjunction_tests {
     fn Test5AndTest5IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test5") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -713,6 +889,8 @@ mod Conjunction_tests {
     fn Test5AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -720,6 +898,8 @@ mod Conjunction_tests {
     fn Test5AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -727,6 +907,8 @@ mod Conjunction_tests {
     fn Test5AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -734,6 +916,8 @@ mod Conjunction_tests {
     fn Test5AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -741,6 +925,8 @@ mod Conjunction_tests {
     fn Test5AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -748,6 +934,8 @@ mod Conjunction_tests {
     fn Test5AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -755,6 +943,8 @@ mod Conjunction_tests {
     fn Test5AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test5&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -762,6 +952,8 @@ mod Conjunction_tests {
     fn Test6AndTest6IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test6") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -769,6 +961,8 @@ mod Conjunction_tests {
     fn Test6AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -776,6 +970,8 @@ mod Conjunction_tests {
     fn Test6AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -783,6 +979,8 @@ mod Conjunction_tests {
     fn Test6AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -790,6 +988,8 @@ mod Conjunction_tests {
     fn Test6AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -797,6 +997,8 @@ mod Conjunction_tests {
     fn Test6AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -804,6 +1006,8 @@ mod Conjunction_tests {
     fn Test6AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test6&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -811,6 +1015,8 @@ mod Conjunction_tests {
     fn Test7AndTest7IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test7") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -818,6 +1024,8 @@ mod Conjunction_tests {
     fn Test7AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -825,6 +1033,8 @@ mod Conjunction_tests {
     fn Test7AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -832,6 +1042,8 @@ mod Conjunction_tests {
     fn Test7AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -839,6 +1051,8 @@ mod Conjunction_tests {
     fn Test7AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -846,6 +1060,8 @@ mod Conjunction_tests {
     fn Test7AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test7&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -853,6 +1069,8 @@ mod Conjunction_tests {
     fn Test8AndTest8IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test8") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -860,6 +1078,8 @@ mod Conjunction_tests {
     fn Test8AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -867,6 +1087,8 @@ mod Conjunction_tests {
     fn Test8AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -874,6 +1096,8 @@ mod Conjunction_tests {
     fn Test8AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -881,6 +1105,8 @@ mod Conjunction_tests {
     fn Test8AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test8&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -888,6 +1114,8 @@ mod Conjunction_tests {
     fn Test9AndTest9IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test9") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -895,6 +1123,8 @@ mod Conjunction_tests {
     fn Test9AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -902,6 +1132,8 @@ mod Conjunction_tests {
     fn Test9AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -909,6 +1141,8 @@ mod Conjunction_tests {
     fn Test9AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test9&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -916,6 +1150,8 @@ mod Conjunction_tests {
     fn Test10AndTest10IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test10") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -923,6 +1159,8 @@ mod Conjunction_tests {
     fn Test10AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -930,6 +1168,8 @@ mod Conjunction_tests {
     fn Test10AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test10&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -937,6 +1177,8 @@ mod Conjunction_tests {
     fn Test11AndTest11IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11&&Test11") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -944,6 +1186,8 @@ mod Conjunction_tests {
     fn Test11AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test11&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 
@@ -951,6 +1195,8 @@ mod Conjunction_tests {
     fn Test12AndTest12IsConsistent() {
         if let QueryResult::Consistency(res) = json_run_query(PATH, "consistency:Test12&&Test12") {
             assert!(res)
+        } else {
+            assert!(false)
         }
     }
 }

--- a/src/tests/consistency/mod.rs
+++ b/src/tests/consistency/mod.rs
@@ -1,0 +1,1 @@
+pub mod conjunction;

--- a/src/tests/consistency/mod.rs
+++ b/src/tests/consistency/mod.rs
@@ -1,1 +1,2 @@
+pub mod composition;
 pub mod conjunction;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod ModelObjects;
+pub mod consistency;
 pub mod dbm;
 pub mod refinement;
 pub mod sample;

--- a/src/tests/refinement/xml/consistency_tests.rs
+++ b/src/tests/refinement/xml/consistency_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod consistency_tests {
+    use crate::tests::refinement::Helper;
     use crate::tests::refinement::Helper::xml_run_query;
     use crate::System::executable_query::QueryResult;
 
@@ -15,6 +16,7 @@ mod consistency_tests {
             panic!("Not consistency check");
         }
     }
+
     #[test]
     fn testG2() {
         let result = xml_run_query(PATH, "consistency: G2");


### PR DESCRIPTION
To check whether a whole system is consistent an extra check has been made.

Additionally some tests were generated for this case, some of these are assumed to fail based off of the tests on https://github.com/Ecdar/Reveaal/commit/f9cfe42e5e77a41d41619c73c9fb2665de8061e0

However it seems that 
`tests::consistency::conjunction::Conjunction_tests::HalfAdm2AndSpecIsNotConsistent` is consistent, which might indicate an error in either the consistency check or save component.