### PR TITLE
State struct refactor

### DIFF
--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -2,7 +2,7 @@ use crate::DBMLib::lib;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, std::cmp::PartialEq)]
 pub struct Zone {
     pub(crate) dimension: u32,
     pub(in crate::DBMLib) matrix: Vec<i32>,
@@ -223,6 +223,16 @@ impl Zone {
             self.dimension,
             max_bounds.clock_bounds.as_ptr(),
         );
+    }
+
+    pub fn canDelayIndefinitely(&self) -> bool {
+        for i in 1..self.dimension {
+            if !self.is_constraint_infinity(i, 0) {
+                return false;
+            }
+        }
+
+        true
     }
 }
 

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -325,16 +325,17 @@ pub fn apply_constraints_to_state_helper(
 pub fn apply_constraints_to_state2(
     guard: &BoolExpression,
     state: &mut component::State,
+    comp_index: usize,
 ) -> BoolExpression {
     match guard {
         BoolExpression::AndOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state);
+            let left = apply_constraints_to_state2(&**left, state, comp_index);
             if let BoolExpression::Bool(val) = left {
                 if !val {
                     return BoolExpression::Bool(false);
                 }
             }
-            let right = apply_constraints_to_state2(&**right, state);
+            let right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match left {
                 BoolExpression::Bool(left_val) => match right {
@@ -351,8 +352,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::OrOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state);
-            let right = apply_constraints_to_state2(&**right, state);
+            let left = apply_constraints_to_state2(&**left, state, comp_index);
+            let right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match left {
                 BoolExpression::Bool(left_val) => match right {
@@ -367,8 +368,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::LessEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
@@ -400,8 +401,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
@@ -432,8 +433,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::LessT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
@@ -465,8 +466,8 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
@@ -496,11 +497,19 @@ pub fn apply_constraints_to_state2(
                 }
             }
         }
-        BoolExpression::Parentheses(expr) => apply_constraints_to_state2(expr, state),
+        BoolExpression::Parentheses(expr) => apply_constraints_to_state2(expr, state, comp_index),
         BoolExpression::VarName(name) => {
-            if let Some(clock_index) = state.get_declarations().get_clocks().get(name.as_str()) {
+            if let Some(clock_index) = state
+                .get_declarations(comp_index)
+                .get_clocks()
+                .get(name.as_str())
+            {
                 BoolExpression::Clock(*clock_index)
-            } else if let Some(val) = state.get_declarations().get_ints().get(name.as_str()) {
+            } else if let Some(val) = state
+                .get_declarations(comp_index)
+                .get_ints()
+                .get(name.as_str())
+            {
                 BoolExpression::Int(*val)
             } else {
                 panic!("no variable or clock named {:?}", name)
@@ -511,8 +520,8 @@ pub fn apply_constraints_to_state2(
         BoolExpression::Clock(index) => BoolExpression::Clock(*index),
         //_ => {}
         BoolExpression::EQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state);
-            let computed_right = apply_constraints_to_state2(&**right, state);
+            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
+            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -6,7 +6,7 @@ use crate::ModelObjects::representations::BoolExpression;
 /// Used to handle update expressions on edges
 pub fn updater(
     updates: &[parse_edge::Update],
-    state: &mut component::DecoratedLocation,
+    state: &component::DecoratedLocation,
     zone: &mut Zone,
 ) {
     for update in updates {
@@ -29,12 +29,16 @@ pub fn updater(
 }
 
 /// Used to handle update expressions on edges
-pub fn fullState_updater(updates: &[parse_edge::Update], state: &mut component::State) {
+pub fn state_updater(
+    updates: &[parse_edge::Update],
+    state: &mut component::State,
+    comp_index: usize,
+) {
     for update in updates {
         match update.get_expression() {
             BoolExpression::Int(val) => {
                 if let Some(&clock_index) = state
-                    .get_declarations()
+                    .get_declarations(comp_index)
                     .get_clock_index_by_name(update.get_variable_name())
                 {
                     state.zone.update(clock_index, *val);

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -392,7 +392,11 @@ impl Component {
                     .get_invariant()
                 {
                     if let BoolExpression::Bool(false) =
-                        constraint_applyer::apply_constraints_to_state2(source_inv, &mut new_state, 0)
+                        constraint_applyer::apply_constraints_to_state2(
+                            source_inv,
+                            &mut new_state,
+                            0,
+                        )
                     {
                         continue;
                     };
@@ -414,7 +418,7 @@ impl Component {
                     .get_location_by_name(edge.get_target_location())
                     .get_invariant()
                 {
-                    constraint_applyer::apply_constraints_to_state2(target_inv, &mut new_state,0);
+                    constraint_applyer::apply_constraints_to_state2(target_inv, &mut new_state, 0);
                 }
 
                 if !new_state.zone.is_valid() {
@@ -504,7 +508,7 @@ impl Component {
                                 constraint_applyer::apply_constraints_to_state2(
                                     guard,
                                     &mut new_state,
-                                    0
+                                    0,
                                 )
                             {
                             } else {
@@ -627,9 +631,7 @@ fn is_new_state<'a>(state: &mut State<'a>, passed_list: &mut Vec<State<'a>>) -> 
     assert_eq!(state.decorated_locations.len(), 1);
 
     for passed_state_pair in passed_list {
-        if state.get_location(0).get_id()
-            != passed_state_pair.get_location(0).get_id()
-        {
+        if state.get_location(0).get_id() != passed_state_pair.get_location(0).get_id() {
             continue;
         }
         if state.zone.dimension != passed_state_pair.zone.dimension {
@@ -670,30 +672,33 @@ pub struct State<'a> {
 }
 
 impl<'a> State<'a> {
-    pub fn create(decorated_locations: DecoratedLocationTuple<'a>, zone: Zone) -> Self{
-        State{
+    pub fn create(decorated_locations: DecoratedLocationTuple<'a>, zone: Zone) -> Self {
+        State {
             decorated_locations,
             zone,
         }
     }
 
-    pub fn from_location(decorated_locations: DecoratedLocationTuple<'a>, dimensions: u32) -> Option<Self>{
+    pub fn from_location(
+        decorated_locations: DecoratedLocationTuple<'a>,
+        dimensions: u32,
+    ) -> Option<Self> {
         let mut zone = Zone::init(dimensions);
 
         for location in &decorated_locations {
-            if !location.apply_invariant(&mut zone){
+            if !location.apply_invariant(&mut zone) {
                 return None;
             }
         }
 
-        Some(State{
+        Some(State {
             decorated_locations,
             zone,
         })
     }
 
     pub fn is_subset_of(&self, other: &Self) -> bool {
-        if self.decorated_locations != other.decorated_locations{
+        if self.decorated_locations != other.decorated_locations {
             return false;
         }
 
@@ -763,7 +768,7 @@ pub struct Transition<'a> {
     pub edges: Vec<(&'a ComponentView<'a>, &'a Edge, usize)>,
 }
 impl<'a> Transition<'a> {
-    pub fn use_transition(&self, state: &mut State<'a>) -> bool{
+    pub fn use_transition(&self, state: &mut State<'a>) -> bool {
         if self.apply_guards(&state.decorated_locations, &mut state.zone) {
             self.apply_updates(&state.decorated_locations, &mut state.zone);
             self.move_locations(&mut state.decorated_locations);

--- a/src/ModelObjects/component_view.rs
+++ b/src/ModelObjects/component_view.rs
@@ -13,13 +13,23 @@ pub struct ComponentView<'a> {
 impl<'a> ComponentView<'a> {
     pub fn create(component: &'a Component, clock_index_offset: u32) -> Self {
         let mut declarations = component.get_declarations().clone();
-        declarations.update_clock_indices(clock_index_offset);
+        declarations.set_clock_indices(clock_index_offset);
 
         ComponentView {
             component,
             declarations,
             clock_index_offset,
         }
+    }
+
+    pub fn set_clock_offset(&mut self, new_offset: u32) {
+        self.declarations
+            .update_clock_indices(new_offset, self.clock_index_offset);
+        self.clock_index_offset = new_offset;
+    }
+
+    pub fn get_clock_offset(&self) -> u32 {
+        self.clock_index_offset
     }
 
     pub fn get_component(&self) -> &'a Component {


### PR DESCRIPTION
Made the state struct support usage with any system, instead of only supporting single components. This was done by allowing state to contain 0 to many decorated locations instead of only 1 decorated location.

This is great as it allows more functions to make use of the state struct improving readability significantly.