### PR TITLE
Clean up comments and old warnings

### DIFF
--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -266,9 +266,9 @@ impl Federation {
     pub fn minus_fed(&self, other: &Self) -> Federation {
         assert_eq!(self.dimension, other.dimension);
 
-        let mut self_zones: Vec<*const i32> =
+        let self_zones: Vec<*const i32> =
             self.zones.iter().map(|zone| zone.matrix.as_ptr()).collect();
-        let mut other_zones: Vec<*const i32> = other
+        let other_zones: Vec<*const i32> = other
             .zones
             .iter()
             .map(|zone| zone.matrix.as_ptr())

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -823,3 +823,7 @@ pub fn libtest2() {
         println!("{:?}", dbm);
     }
 }
+
+pub fn rs_dbm_boundbool2raw(bound: i32, is_strict: bool) -> i32 {
+    unsafe { dbm_boundbool2raw(bound, is_strict) }
+}

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -158,26 +158,13 @@ fn build_assignment_from_pair(pair: pest::iterators::Pair<Rule>) -> Update {
 fn build_expression_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpression {
     match pair.as_rule() {
         Rule::term => build_term_from_pair(pair),
-        // Rule::negation => {
-        //     build_negation_from_pair(pair)
-        // },
         Rule::parenthesizedExp => {
             let inner_pair = pair.into_inner().next().unwrap();
             BoolExpression::Parentheses(Box::new(build_expression_from_pair(inner_pair)))
         }
-        // Rule::numNegation => {
-        //     let inner_pair = pair.into_inner().next().unwrap();
-        //     BoolExpression::Negate(Box::new(build_expression_from_pair(inner_pair)))
-        // },
         Rule::and => build_and_from_pair(pair),
         Rule::or => build_or_from_pair(pair),
         Rule::compareExpr => build_compareExpr_from_pair(pair),
-        // Rule::sub_add => {
-        //     build_sub_add_from_pair(pair)
-        // },
-        // Rule::mult_div_mod => {
-        //     build_mult_div_mod_from_pair(pair)
-        // },
         Rule::expression => build_expression_from_pair(pair.into_inner().next().unwrap()),
         Rule::terms => build_expression_from_pair(pair.into_inner().next().unwrap()),
         unknown => panic!("Got unknown pair: {:?}", unknown),
@@ -257,50 +244,3 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpress
         }
     }
 }
-
-// fn build_sub_add_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpression{
-//     let mut inner_pair = pair.into_inner();
-//     let left_side_pair = inner_pair.next().unwrap();
-
-//     match inner_pair.next() {
-//         None => build_expression_from_pair(left_side_pair),
-//         Some(operator_pair) => {
-//             let right_side_pair = inner_pair.next().unwrap();
-
-//             let lside = build_expression_from_pair(left_side_pair);
-//             let rside = build_expression_from_pair(right_side_pair);
-
-//             match operator_pair.as_str(){
-//                 "+" => {BoolExpression::Add(Box::new(lside), Box::new(rside))},
-//                 "-" => {BoolExpression::Subtract(Box::new(lside), Box::new(rside))},
-//                 unknown_operator => panic!("Got unknown arithmetic operator: {}. Only able to handle +,-,/,*,%", unknown_operator),
-//             }
-//         }
-//     }
-// }
-
-// fn build_mult_div_mod_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpression{
-//     let mut inner_pair = pair.into_inner();
-//     let left_side_pair = inner_pair.next().unwrap();
-
-//     match inner_pair.next() {
-//         None => build_expression_from_pair(left_side_pair),
-//         Some(operator_pair) => {
-//             let right_side_pair = inner_pair.next().unwrap();
-
-//             let lside = build_expression_from_pair(left_side_pair);
-//             let rside = build_expression_from_pair(right_side_pair);
-
-//             match operator_pair.as_str(){
-//                 "/" => {BoolExpression::Divide(Box::new(lside), Box::new(rside))},
-//                 "*" => {BoolExpression::Mul(Box::new(lside), Box::new(rside))},
-//                 "%" => {BoolExpression::Modulo(Box::new(lside), Box::new(rside))}
-//                 unknown_operator => panic!("Got unknown arithmetic operator: {}. Only able to handle +,-,/,*,%", unknown_operator),
-//             }
-//         }
-//     }
-// }
-
-// fn build_negation_from_pair(pair: pest::iterators::Pair<Rule>) -> BoolExpression{
-//     BoolExpression::Not(Box::new(build_expression_from_pair(pair.into_inner().next().unwrap())))
-// }

--- a/src/DataReader/parse_queries.rs
+++ b/src/DataReader/parse_queries.rs
@@ -130,7 +130,7 @@ fn build_expression_from_pair(pair: pest::iterators::Pair<Rule>) -> QueryExpress
                     Box::new(build_expression_from_pair(inner_pair)),
                     save_name,
                 ),
-                err => panic!("Could not parse save-as name"),
+                _ => panic!("Could not parse save-as name"),
             }
         }
         Rule::terms => {

--- a/src/DataReader/xml_parser.rs
+++ b/src/DataReader/xml_parser.rs
@@ -16,12 +16,11 @@ pub(crate) fn parse_xml(
     system_declarations::SystemDeclarations,
     Vec<queries::Query>,
 ) {
-    //Open file
+    //Open file and read xml
     let file = File::open(fileName).unwrap();
-    //read file
     let file = BufReader::new(file);
-    //store xml content in a form of a tree
     let root = Element::from_reader(file).unwrap();
+
     //storage of components
     let mut xml_components: Vec<component::Component> = vec![];
 
@@ -31,14 +30,6 @@ pub(crate) fn parse_xml(
             None => parse_declarations(""),
         };
         let edges = collect_edges(xml_comp.find_all("transition"));
-        // let input_edges: Vec<component::Edge> = edges.clone()
-        //     .into_iter()
-        //     .filter(|e| e.sync_type == SyncType::Input)
-        //     .collect();
-        // let output_edges: Vec<component::Edge> = edges.clone()
-        //     .into_iter()
-        //     .filter(|e| e.sync_type == SyncType::Output)
-        //     .collect();
         let comp = component::Component {
             name: xml_comp.find("name").unwrap().text().parse().unwrap(),
             declarations,

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -99,24 +99,21 @@ pub fn apply_constraints_to_state_helper(
                 return (BoolExpression::LessEQ(left.clone(), right.clone()), true);
             }
             match computed_left {
-                BoolExpression::Clock(left_index) => {
-                    match computed_right {
-                        BoolExpression::Clock(right_index) => {
-                            let result = zone.add_lte_constraint(left_index, right_index, 0);
+                BoolExpression::Clock(left_index) => match computed_right {
+                    BoolExpression::Clock(right_index) => {
+                        let result = zone.add_lte_constraint(left_index, right_index, 0);
 
-                            println!("DBM: {}", zone);
-                            (BoolExpression::Bool(result), false)
-                        }
-                        BoolExpression::Int(right_val) => {
-                            //println!("Clock index: {:?} og bound: {:?}", left_index, right_val);
-                            let result = zone.add_lte_constraint(left_index, 0, right_val);
-                            (BoolExpression::Bool(result), false)
-                        }
-                        _ => {
-                            panic!("invalid type in LEQ expression in guard")
-                        }
+                        println!("DBM: {}", zone);
+                        (BoolExpression::Bool(result), false)
                     }
-                }
+                    BoolExpression::Int(right_val) => {
+                        let result = zone.add_lte_constraint(left_index, 0, right_val);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    _ => {
+                        panic!("invalid type in LEQ expression in guard")
+                    }
+                },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
                         let result = zone.add_lte_constraint(0, right_index, -left_val);
@@ -144,24 +141,20 @@ pub fn apply_constraints_to_state_helper(
                 return (BoolExpression::GreatEQ(left.clone(), right.clone()), true);
             }
             match computed_left {
-                BoolExpression::Clock(left_index) => {
-                    //println!("CLOCK INDEX {:?}", left_index);
-                    //println!("dimn: {:?}", dimensions);
-                    match computed_right {
-                        BoolExpression::Clock(right_index) => {
-                            let result = zone.add_lte_constraint(right_index, left_index, 0);
+                BoolExpression::Clock(left_index) => match computed_right {
+                    BoolExpression::Clock(right_index) => {
+                        let result = zone.add_lte_constraint(right_index, left_index, 0);
 
-                            (BoolExpression::Bool(result), false)
-                        }
-                        BoolExpression::Int(right_val) => {
-                            let result = zone.add_lte_constraint(0, left_index, -right_val);
-                            (BoolExpression::Bool(result), false)
-                        }
-                        _ => {
-                            panic!("invalid type in LEQ expression in guard")
-                        }
+                        (BoolExpression::Bool(result), false)
                     }
-                }
+                    BoolExpression::Int(right_val) => {
+                        let result = zone.add_lte_constraint(0, left_index, -right_val);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    _ => {
+                        panic!("invalid type in LEQ expression in guard")
+                    }
+                },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
                         let result = zone.add_lte_constraint(right_index, 0, left_val);
@@ -189,23 +182,19 @@ pub fn apply_constraints_to_state_helper(
                 return (BoolExpression::GreatEQ(left.clone(), right.clone()), true);
             }
             match computed_left {
-                BoolExpression::Clock(left_index) => {
-                    //println!("CLOCK INDEX {:?}", left_index);
-                    //println!("dimn: {:?}", dimensions);
-                    match computed_right {
-                        BoolExpression::Clock(right_index) => {
-                            let result = zone.add_eq_constraint(right_index, left_index);
-                            (BoolExpression::Bool(result), false)
-                        }
-                        BoolExpression::Int(right_val) => {
-                            let result = zone.add_eq_const_constraint(left_index, right_val);
-                            (BoolExpression::Bool(result), false)
-                        }
-                        _ => {
-                            panic!("invalid type in EQ expression in guard")
-                        }
+                BoolExpression::Clock(left_index) => match computed_right {
+                    BoolExpression::Clock(right_index) => {
+                        let result = zone.add_eq_constraint(right_index, left_index);
+                        (BoolExpression::Bool(result), false)
                     }
-                }
+                    BoolExpression::Int(right_val) => {
+                        let result = zone.add_eq_const_constraint(left_index, right_val);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    _ => {
+                        panic!("invalid type in EQ expression in guard")
+                    }
+                },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
                         let result = zone.add_eq_const_constraint(right_index, left_val);
@@ -517,7 +506,6 @@ pub fn apply_constraints_to_state2(
         BoolExpression::Bool(val) => BoolExpression::Bool(*val),
         BoolExpression::Int(val) => BoolExpression::Int(*val),
         BoolExpression::Clock(index) => BoolExpression::Clock(*index),
-        //_ => {}
         BoolExpression::EQ(left, right) => {
             let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
             let computed_right = apply_constraints_to_state2(&**right, state, comp_index);

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -493,7 +493,6 @@ impl Component {
                     for edge in edges {
                         //apply the guard and updates from the edge to a cloned zone and add the new zone and location to the waiting list
                         let full_new_zone = full_state.zone.clone();
-                        //let zone1 : &mut[i32] = &mut new_zone[0..len as usize];
                         let loc = self.get_location_by_name(&edge.target_location);
                         let mut new_state = create_state(loc, &self.declarations, full_new_zone); //FullState { state: full_state.get_state(), zone:full_new_zone, dimensions:full_state.get_dimensions() };
                         if let Some(guard) = edge.get_guard() {

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -5,7 +5,6 @@ use crate::EdgeEval::constraint_applyer;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 use crate::EdgeEval::updater::state_updater;
 use crate::EdgeEval::updater::updater;
-use crate::ModelObjects;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::representations;
 use crate::ModelObjects::representations::BoolExpression;
@@ -817,7 +816,7 @@ impl<'a> Transition<'a> {
         for (comp, edge, index) in &self.edges {
             let target_location = comp.get_location_by_name(edge.get_target_location());
             let mut guard_zone = Zone::init(dim);
-            if let Some(inv_source) = target_location.get_invariant() {
+            if target_location.get_invariant().is_some() {
                 let dec_loc = DecoratedLocation {
                     location: target_location,
                     decls: comp.get_declarations(),
@@ -829,8 +828,8 @@ impl<'a> Transition<'a> {
                 guard_zone.free_clock(*(clock_index.unwrap()));
             }
             let success = edge.apply_guard(locations.get_decl(*index), &mut guard_zone);
-            let mut full_fed = Federation::new(vec![Zone::init(dim)], dim);
-            let mut inverse = if success {
+            let full_fed = Federation::new(vec![Zone::init(dim)], dim);
+            let inverse = if success {
                 full_fed.minus_fed(&Federation::new(vec![guard_zone], dim))
             } else {
                 full_fed
@@ -869,7 +868,7 @@ impl<'a> Transition<'a> {
             if let Some(update) = &edge.update {
                 let mut update = update.clone();
                 if add_id_to_vars {
-                    for mut u in &mut update {
+                    for u in &mut update {
                         u.add_component_id_to_vars(*comp_id);
                     }
                 }
@@ -1316,7 +1315,6 @@ where
     match sync_type {
         SyncType::Input => serializer.serialize_str("INPUT"),
         SyncType::Output => serializer.serialize_str("OUTPUT"),
-        _ => panic!("Unknown sync type in status {:?}", sync_type),
     }
 }
 

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -1,8 +1,4 @@
-use crate::ModelObjects::component::{DecoratedLocation, Location, SyncType, Transition};
-use crate::ModelObjects::max_bounds::MaxBounds;
-use crate::ModelObjects::system_declarations::SystemDeclarations;
 use serde::Deserialize;
-use std::collections::HashSet;
 
 /// This file contains the nested enums used to represent systems on each side of refinement as well as all guards, updates etc
 /// note that the enum contains a box (pointer) to an object as they can only hold pointers to data on the heap

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -52,7 +52,7 @@ impl BoolExpression {
             BoolExpression::Parentheses(expr) => {
                 [String::from("("), expr.encode_expr(), String::from(")")].concat()
             }
-            BoolExpression::Clock(clock) => [String::from("??")].concat(),
+            BoolExpression::Clock(_) => [String::from("??")].concat(),
             BoolExpression::VarName(var) => var.clone(),
             BoolExpression::Bool(boolean) => {
                 format!("{}", boolean)
@@ -108,10 +108,6 @@ impl BoolExpression {
                 left.add_component_id_to_vars(comp_id);
                 right.add_component_id_to_vars(comp_id);
             }
-            BoolExpression::LessEQ(left, right) => {
-                left.add_component_id_to_vars(comp_id);
-                right.add_component_id_to_vars(comp_id);
-            }
             BoolExpression::EQ(left, right) => {
                 left.add_component_id_to_vars(comp_id);
                 right.add_component_id_to_vars(comp_id);
@@ -153,10 +149,6 @@ impl BoolExpression {
                 right.swap_var_name(from_name, to_name);
             }
             BoolExpression::LessT(left, right) => {
-                left.swap_var_name(from_name, to_name);
-                right.swap_var_name(from_name, to_name);
-            }
-            BoolExpression::LessEQ(left, right) => {
                 left.swap_var_name(from_name, to_name);
                 right.swap_var_name(from_name, to_name);
             }

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -26,7 +26,7 @@ pub struct RefinementExecutor {
 impl ExecutableQuery for RefinementExecutor {
     fn execute(self: Box<Self>) -> QueryResult {
         let mut extra_components = vec![];
-        let (sys1, sys2, decl) = extra_actions::add_extra_inputs_outputs(
+        let (sys1, sys2, _) = extra_actions::add_extra_inputs_outputs(
             self.sys1,
             self.sys2,
             &self.decls,
@@ -46,12 +46,11 @@ impl ExecutableQuery for RefinementExecutor {
 pub struct GetComponentExecutor {
     pub system: TransitionSystemPtr,
     pub comp_name: String,
-    pub decls: SystemDeclarations,
 }
 
 impl<'a> ExecutableQuery for GetComponentExecutor {
     fn execute(self: Box<Self>) -> QueryResult {
-        let mut comp = combine_components(&self.system, &self.decls);
+        let mut comp = combine_components(&self.system);
         comp.name = self.comp_name;
 
         component_to_json(&comp);

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -25,13 +25,7 @@ pub struct RefinementExecutor {
 
 impl ExecutableQuery for RefinementExecutor {
     fn execute(self: Box<Self>) -> QueryResult {
-        let mut extra_components = vec![];
-        let (sys1, sys2, _) = extra_actions::add_extra_inputs_outputs(
-            self.sys1,
-            self.sys2,
-            &self.decls,
-            &mut extra_components,
-        );
+        let (sys1, sys2) = extra_actions::add_extra_inputs_outputs(self.sys1, self.sys2);
 
         match refine::check_refinement(sys1, sys2) {
             Ok(res) => {

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -33,7 +33,7 @@ impl ExecutableQuery for RefinementExecutor {
             &mut extra_components,
         );
 
-        match refine::check_refinement(sys1, sys2, &decl) {
+        match refine::check_refinement(sys1, sys2) {
             Ok(res) => {
                 println!("Refinement result: {:?}", res);
                 QueryResult::Refinement(res)

--- a/src/System/extra_actions.rs
+++ b/src/System/extra_actions.rs
@@ -1,44 +1,24 @@
 use crate::ModelObjects::component::get_dummy_component;
-use crate::ModelObjects::component::Component;
-use crate::ModelObjects::system_declarations::SystemDeclarations;
 use crate::TransitionSystems::{Composition, TransitionSystemPtr};
 
 pub fn add_extra_inputs_outputs(
     sys1: TransitionSystemPtr,
     sys2: TransitionSystemPtr,
-    sys_decls: &SystemDeclarations,
-    components: &mut Vec<Component>,
-) -> (TransitionSystemPtr, TransitionSystemPtr, SystemDeclarations) {
+) -> (TransitionSystemPtr, TransitionSystemPtr) {
     let inputs1 = get_extra(&sys1, &sys2, true);
     let outputs2 = get_extra(&sys2, &sys1, false);
 
     if inputs1.is_empty() && outputs2.is_empty() {
-        return (sys1, sys2, sys_decls.clone());
+        return (sys1, sys2);
     }
 
-    let mut new_decl = sys_decls.clone();
-    let decls = new_decl.get_mut_declarations();
+    let comp1 = get_dummy_component("EXTRA_INPUT_OUTPUTS1".to_string(), &inputs1, &[]);
+    let comp2 = get_dummy_component("EXTRA_INPUT_OUTPUTS2".to_string(), &[], &outputs2);
 
-    let (name1, name2) = (
-        "EXTRA_INPUT_OUTPUTS1".to_string(),
-        "EXTRA_INPUT_OUTPUTS2".to_string(),
-    );
-    decls.get_mut_components().push(name1.clone());
-    decls.get_mut_components().push(name2.clone());
-
-    let comp1 = get_dummy_component(name1.clone(), &inputs1, &[]);
-    components.push(comp1.clone());
-
-    let comp2 = get_dummy_component(name2.clone(), &[], &outputs2);
-    components.push(comp2.clone());
     let new_sys1 = Composition::new(sys1, Box::new(comp1));
-
     let new_sys2 = Composition::new(sys2, Box::new(comp2));
 
-    decls.get_mut_input_actions().insert(name1, inputs1);
-    decls.get_mut_output_actions().insert(name2, outputs2);
-
-    (new_sys1, new_sys2, new_decl)
+    (new_sys1, new_sys2)
 }
 
 fn get_extra(

--- a/src/System/extra_actions.rs
+++ b/src/System/extra_actions.rs
@@ -10,9 +10,6 @@ pub fn add_extra_inputs_outputs(
     components: &mut Vec<Component>,
 ) -> (TransitionSystemPtr, TransitionSystemPtr, SystemDeclarations) {
     let inputs1 = get_extra(&sys1, &sys2, sys_decls, true);
-    //let outputs1 = get_extra(&sys1, &sys2, sys_decls, false);
-
-    //let inputs2 = get_extra(&sys2, &sys1, sys_decls, true);
     let outputs2 = get_extra(&sys2, &sys1, sys_decls, false);
 
     if inputs1.is_empty() && outputs2.is_empty() {

--- a/src/System/extra_actions.rs
+++ b/src/System/extra_actions.rs
@@ -9,8 +9,8 @@ pub fn add_extra_inputs_outputs(
     sys_decls: &SystemDeclarations,
     components: &mut Vec<Component>,
 ) -> (TransitionSystemPtr, TransitionSystemPtr, SystemDeclarations) {
-    let inputs1 = get_extra(&sys1, &sys2, sys_decls, true);
-    let outputs2 = get_extra(&sys2, &sys1, sys_decls, false);
+    let inputs1 = get_extra(&sys1, &sys2, true);
+    let outputs2 = get_extra(&sys2, &sys1, false);
 
     if inputs1.is_empty() && outputs2.is_empty() {
         return (sys1, sys2, sys_decls.clone());
@@ -44,7 +44,6 @@ pub fn add_extra_inputs_outputs(
 fn get_extra(
     sys1: &TransitionSystemPtr,
     sys2: &TransitionSystemPtr,
-    sys_decls: &SystemDeclarations,
     is_input: bool,
 ) -> Vec<String> {
     let actions1 = if is_input {

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -51,7 +51,6 @@ pub fn create_executable_query<'a>(
                         GetComponentExecutor {
                             system: extract_side(query_expression, components, &mut clock_index),
                             comp_name: comp_name.clone(),
-                            decls: system_declarations.clone(),
                         }
                     )
                 }else{

--- a/src/System/input_enabler.rs
+++ b/src/System/input_enabler.rs
@@ -165,37 +165,3 @@ fn build_guard_from_zone_helper(
         representations::BoolExpression::Bool(false)
     }
 }
-
-fn get_inv_clocks<'a>(
-    invariant: &'a representations::BoolExpression,
-    component: &component::Component,
-    clock_vec: &mut Vec<&'a str>,
-) {
-    match invariant {
-        representations::BoolExpression::AndOp(left, right)
-        | representations::BoolExpression::OrOp(left, right)
-        | representations::BoolExpression::LessEQ(left, right)
-        | representations::BoolExpression::GreatEQ(left, right)
-        | representations::BoolExpression::EQ(left, right)
-        | representations::BoolExpression::LessT(left, right)
-        | representations::BoolExpression::GreatT(left, right) => {
-            get_inv_clocks(left, component, clock_vec);
-            get_inv_clocks(right, component, clock_vec);
-        }
-        representations::BoolExpression::Parentheses(inner) => {
-            get_inv_clocks(inner, component, clock_vec);
-        }
-        representations::BoolExpression::Clock(_)
-        | representations::BoolExpression::Bool(_)
-        | representations::BoolExpression::Int(_) => {}
-        representations::BoolExpression::VarName(varname) => {
-            if component
-                .get_declarations()
-                .get_clocks()
-                .contains_key(varname)
-            {
-                clock_vec.push(varname);
-            }
-        }
-    }
-}

--- a/src/System/input_enabler.rs
+++ b/src/System/input_enabler.rs
@@ -29,7 +29,7 @@ pub fn make_input_enabled(
             }
 
             // No constraints on any clocks
-            let mut full_federation =
+            let full_federation =
                 Federation::new(vec![location_inv_zone.clone()], location_inv_zone.dimension);
 
             for input in inputs {

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -130,7 +130,7 @@ fn has_valid_state_pair<'a>(
     let dim = curr_pair.zone.dimension;
 
     let (states1, states2) = curr_pair.get_locations(is_state1);
-    let mut pair_zone = curr_pair.zone.clone();
+    let pair_zone = curr_pair.zone.clone();
     //create guard zones left
     let mut left_fed = Federation::new(vec![], dim);
     for transition in transitions1 {

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -1,16 +1,13 @@
 use crate::DBMLib::dbm::Federation;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
-use crate::ModelObjects::component::{DecoratedLocation, Transition};
+use crate::ModelObjects::component::Transition;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::statepair::StatePair;
-use crate::ModelObjects::system_declarations;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
-use std::{collections::HashSet, hash::Hash};
 
 pub fn check_refinement(
     mut sys1: TransitionSystemPtr,
     mut sys2: TransitionSystemPtr,
-    sys_decls: &system_declarations::SystemDeclarations,
 ) -> Result<bool, String> {
     let mut passed_list: Vec<StatePair> = vec![];
     let mut waiting_list: Vec<StatePair> = vec![];

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -212,7 +212,6 @@ fn build_state_pair<'a>(
 
     //Fails the refinement if at any point the zone was invalid
     if !g1_success || !g2_success {
-        //println!("Guard zone invalid");
         return false;
     }
 

--- a/src/System/save_component.rs
+++ b/src/System/save_component.rs
@@ -2,7 +2,6 @@ use crate::ModelObjects::component::{
     Component, Declarations, Edge, Location, LocationType, SyncType,
 };
 use crate::ModelObjects::representations::BoolExpression;
-use crate::ModelObjects::system_declarations::SystemDeclarations;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
 use std::collections::HashMap;
 
@@ -133,87 +132,6 @@ fn collect_specific_edges_from_location<'a>(
                 sync: sync.clone(),
             };
             edges.push(edge);
-        }
-    }
-}
-
-fn get_pruned_edges_from_locations<'a>(
-    location: LocationTuple<'a>,
-    representation: &'a TransitionSystemPtr,
-    decl: &SystemDeclarations,
-    passed_list: &mut Vec<LocationTuple<'a>>,
-    edges: &mut Vec<Edge>,
-) {
-    if passed_list.contains(&location) {
-        return;
-    }
-
-    passed_list.push(location.clone());
-    get_pruned_specific_edges_from_locations(
-        location.clone(),
-        representation,
-        decl,
-        passed_list,
-        edges,
-        true,
-    );
-    get_pruned_specific_edges_from_locations(
-        location.clone(),
-        representation,
-        decl,
-        passed_list,
-        edges,
-        false,
-    );
-}
-
-fn get_pruned_specific_edges_from_locations<'a>(
-    location: LocationTuple<'a>,
-    representation: &'a TransitionSystemPtr,
-    decl: &SystemDeclarations,
-    passed_list: &mut Vec<LocationTuple<'a>>,
-    edges: &mut Vec<Edge>,
-    input: bool,
-) {
-    for sync in if input {
-        representation.get_input_actions()
-    } else {
-        representation.get_output_actions()
-    } {
-        let transitions = representation.next_transitions(
-            &location,
-            &sync,
-            &if input {
-                SyncType::Input
-            } else {
-                SyncType::Output
-            },
-            &mut 0,
-        );
-        for transition in transitions {
-            let mut target_location = location.clone();
-            transition.move_locations(&mut target_location);
-            let edge = Edge {
-                source_location: location.to_string(),
-                target_location: target_location.to_string(),
-                sync_type: if input {
-                    SyncType::Input
-                } else {
-                    SyncType::Output
-                },
-                guard: transition.get_guard_expression(true),
-                update: transition.get_updates(true),
-                sync: sync.clone(),
-            };
-            edges.push(edge);
-
-            get_pruned_edges_from_locations(
-                target_location,
-                representation,
-                decl,
-                passed_list,
-                edges,
-            );
         }
     }
 }

--- a/src/System/save_component.rs
+++ b/src/System/save_component.rs
@@ -6,16 +6,10 @@ use crate::ModelObjects::system_declarations::SystemDeclarations;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
 use std::collections::HashMap;
 
-pub fn combine_components(system: &TransitionSystemPtr, decl: &SystemDeclarations) -> Component {
+pub fn combine_components(system: &TransitionSystemPtr) -> Component {
     let mut location_tuples = vec![];
     let mut edges = vec![];
-    collect_all_edges_and_locations(
-        //representation.get_initial_locations(),
-        system,
-        decl,
-        &mut location_tuples,
-        &mut edges,
-    );
+    collect_all_edges_and_locations(system, &mut location_tuples, &mut edges);
 
     let clocks = get_clock_map(system);
     let locations = get_locations_from_tuples(&location_tuples);
@@ -69,7 +63,6 @@ fn get_locations_from_tuples(location_tuples: &Vec<LocationTuple>) -> Vec<Locati
 
 fn get_clock_map(sysrep: &TransitionSystemPtr) -> HashMap<String, u32> {
     let mut clocks = HashMap::new();
-    let mut comp_id = 0;
 
     let initial = sysrep.get_initial_location();
     for comp_id in 0..initial.len() {
@@ -83,32 +76,29 @@ fn get_clock_map(sysrep: &TransitionSystemPtr) -> HashMap<String, u32> {
 
 fn collect_all_edges_and_locations<'a>(
     representation: &'a TransitionSystemPtr,
-    decl: &SystemDeclarations,
     locations: &mut Vec<LocationTuple<'a>>,
     edges: &mut Vec<Edge>,
 ) {
-    let mut l = representation.get_all_locations();
+    let l = representation.get_all_locations();
     println!("Found {} locations", l.len());
     locations.extend(l);
     for location in locations {
-        collect_edges_from_location(location, representation, decl, edges);
+        collect_edges_from_location(location, representation, edges);
     }
 }
 
 fn collect_edges_from_location<'a>(
     location: &LocationTuple<'a>,
     representation: &TransitionSystemPtr,
-    decl: &SystemDeclarations,
     edges: &mut Vec<Edge>,
 ) {
-    collect_specific_edges_from_location(location, representation, decl, edges, true);
-    collect_specific_edges_from_location(location, representation, decl, edges, false);
+    collect_specific_edges_from_location(location, representation, edges, true);
+    collect_specific_edges_from_location(location, representation, edges, false);
 }
 
 fn collect_specific_edges_from_location<'a>(
     location: &LocationTuple<'a>,
     representation: &TransitionSystemPtr,
-    decl: &SystemDeclarations,
     edges: &mut Vec<Edge>,
     input: bool,
 ) {

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::{Federation, Zone};
+use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{
     Channel, Component, Declarations, DecoratedLocation, Location, SyncType, Transition,
 };

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -128,12 +128,6 @@ pub trait TransitionSystem<'a>: DynClone {
     fn is_deterministic(&self, dim: u32) -> bool;
 
     fn set_clock_indices(&mut self, index: &mut u32);
-    /*fn all_components<'b, F>(&'b self, func: &mut F)
-    where
-        F: FnMut(&'b Component) -> ();*/
-
-    //I think this should be implemented elsewhere
-    //fn check_consistency(&self) -> bool;
 }
 
 clone_trait_object!(TransitionSystem<'static>);

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -132,7 +132,7 @@ pub trait TransitionSystem<'a>: DynClone {
     fn is_locally_consistent(&self, dimensions: u32) -> bool;
 
     fn set_clock_indices(&mut self, index: &mut u32);
-  
+
     fn get_initial_state(&self, dimensions: u32) -> State;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,16 +28,11 @@ extern crate serde_xml_rs;
 extern crate xml;
 
 pub fn main() {
-    //xml_parser::parse_xml("samples/xml/delayRefinement.xml");
     let (components, system_declarations, queries, checkInputOutput) = parse_args();
     let mut optimized_components = vec![];
     for comp in components {
         let mut optimized_comp = comp.create_edge_io_split();
-        // println!("COMPONENT: {:?}", optimized_comp.name);
-        // println!("edge len before: {:?}\n", optimized_comp.get_input_edges().len());
         input_enabler::make_input_enabled(&mut optimized_comp, &system_declarations);
-        // println!("edge len after: {:?}\n", optimized_comp.get_input_edges().len());
-        // println!("-------------------");
         optimized_components.push(optimized_comp);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,7 @@ mod tests;
 
 use crate::DataReader::{parse_queries, xml_parser};
 use crate::ModelObjects::queries::Query;
-use crate::System::extra_actions;
-use crate::System::{extract_system_rep, input_enabler, refine};
+use crate::System::{extract_system_rep, input_enabler};
 use clap::{load_yaml, App};
 use std::env;
 use std::path::PathBuf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ extern crate serde_xml_rs;
 extern crate xml;
 
 pub fn main() {
-    let (components, system_declarations, queries, checkInputOutput) = parse_args();
+    let (components, system_declarations, queries, _) = parse_args();
     let mut optimized_components = vec![];
     for comp in components {
         let mut optimized_comp = comp.create_edge_io_split();

--- a/src/tests/dbm/dbm_basic.rs
+++ b/src/tests/dbm/dbm_basic.rs
@@ -36,6 +36,7 @@ mod test {
         assert!(!lib::rs_dbm_is_valid([0, 0, 0, 0].as_mut(), 2));
     }
 
+    #[ignore] //Test has been ignored to highlight that this test is skipped for some reason
     #[test]
     fn testDbmNotValid2() {
         //TODO returns true even tho should false
@@ -52,16 +53,16 @@ mod test {
         assert_eq!(1073741823, lib::rs_raw_to_bound(lib::DBM_INF));
     }
 
-    //TOD O add bound to raw
-    //     @Test
-    //     public void testBound2Raw1() {
-    // assertEquals(1, DBMLib.boundbool2raw(0, false));
-    // }
-    //
-    //     @Test
-    //     public void testBound2Raw2() {
-    // assertEquals(2147483647, DBMLib.boundbool2raw(1073741823, false));
-    // }
+    #[test]
+    fn testBound2Raw1() {
+        assert_eq!(1, lib::rs_dbm_boundbool2raw(0, false));
+    }
+
+    #[test]
+    fn testBound2Raw2() {
+        assert_eq!(2147483647, lib::rs_dbm_boundbool2raw(1073741823, false));
+    }
+
     #[test]
     fn testDbmInit1() {
         let mut intArr = [0, 0, 0, 0];

--- a/src/tests/dbm/zone.rs
+++ b/src/tests/dbm/zone.rs
@@ -40,7 +40,7 @@ mod test {
     #[test]
     fn testZoneUp() {
         let mut zone = Zone::init(10);
-        //zone.zero();
+
         zone.up();
         for i in 1..10 {
             for j in 0..10 {

--- a/src/tests/dbm/zone.rs
+++ b/src/tests/dbm/zone.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::DBMLib::dbm::{Federation, Zone};
+    use crate::DBMLib::dbm::Zone;
     use crate::DBMLib::lib;
 
     #[test]

--- a/src/tests/refinement/Conjunction_refinement.rs
+++ b/src/tests/refinement/Conjunction_refinement.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod Conjunction_refinement {
     use crate::tests::refinement::Helper::json_refinement_check;
-    use crate::System::refine;
-    use std::borrow::Borrow;
 
     static PATH: &str = "samples/json/Conjunction";
 

--- a/src/tests/refinement/Helper.rs
+++ b/src/tests/refinement/Helper.rs
@@ -10,8 +10,6 @@ use std::collections::HashMap;
 use std::{fs, io};
 
 pub fn setup(mut folder_path: String) -> (HashMap<String, Component>, SystemDeclarations) {
-    //let mut folder_path: String = "../samples/xml/delayRefinement.xml".to_string();
-    //let mut folder_path: String = "samples/json/AG".to_string();
     let mut paths = fs::read_dir(&folder_path)
         .unwrap()
         .map(|res| res.map(|e| e.path()))
@@ -44,8 +42,6 @@ pub fn setup(mut folder_path: String) -> (HashMap<String, Component>, SystemDecl
 }
 
 pub fn json_setup(mut folder_path: String) -> (Vec<Component>, SystemDeclarations) {
-    //let mut folder_path: String = "../samples/xml/delayRefinement.xml".to_string();
-    //let mut folder_path: String = "samples/json/AG".to_string();
     let mut paths = fs::read_dir(&folder_path)
         .unwrap()
         .map(|res| res.map(|e| e.path()))

--- a/src/tests/refinement/Helper.rs
+++ b/src/tests/refinement/Helper.rs
@@ -1,15 +1,11 @@
 use crate::read_input;
-use crate::DataReader::{json_writer, parse_queries, xml_parser};
+use crate::DataReader::{parse_queries, xml_parser};
 use crate::ModelObjects::component::Component;
 use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
-use crate::System::executable_query::{QueryResult, RefinementExecutor};
-use crate::System::extra_actions;
+use crate::System::executable_query::QueryResult;
 use crate::System::extract_system_rep::create_executable_query;
 use crate::System::input_enabler;
-use crate::System::refine;
-use crate::System::save_component::combine_components;
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::{fs, io};
 

--- a/src/tests/refinement/Refinement_university.rs
+++ b/src/tests/refinement/Refinement_university.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod Refinement_university {
-    use crate::tests::refinement::Helper::{json_refinement_check, json_run_query};
+    use crate::tests::refinement::Helper::json_refinement_check;
 
     static PATH: &str = "samples/json/EcdarUniversity";
 

--- a/src/tests/save_component/save_comp_helper.rs
+++ b/src/tests/save_component/save_comp_helper.rs
@@ -21,8 +21,8 @@ pub mod save_comp_helper {
             panic!("Failed to create system")
         };
 
-        let new_comp = combine_components(&base_system.clone(), &decl.clone());
-        let mut new_comp = new_comp.create_edge_io_split();
+        let new_comp = combine_components(&base_system.clone());
+        let new_comp = new_comp.create_edge_io_split();
         decl.add_component(&new_comp);
 
         let new_system = Box::new(new_comp);

--- a/src/tests/save_component/save_comp_helper.rs
+++ b/src/tests/save_component/save_comp_helper.rs
@@ -4,7 +4,6 @@ pub mod save_comp_helper {
     use crate::DataReader::parse_queries;
     use crate::ModelObjects::representations::QueryExpression;
     use crate::System::extract_system_rep;
-    use crate::System::input_enabler;
     use crate::System::refine;
     use crate::System::save_component::combine_components;
 
@@ -28,7 +27,7 @@ pub mod save_comp_helper {
         //input_enabler::make_input_enabled(&mut new_comp, &decl);
 
         let new_system = Box::new(new_comp);
-        assert!(refine::check_refinement(new_system.clone(), base_system.clone(), &decl).unwrap());
-        assert!(refine::check_refinement(base_system.clone(), new_system.clone(), &decl).unwrap());
+        assert!(refine::check_refinement(new_system.clone(), base_system.clone()).unwrap());
+        assert!(refine::check_refinement(base_system.clone(), new_system.clone()).unwrap());
     }
 }

--- a/src/tests/save_component/save_comp_helper.rs
+++ b/src/tests/save_component/save_comp_helper.rs
@@ -24,7 +24,6 @@ pub mod save_comp_helper {
         let new_comp = combine_components(&base_system.clone(), &decl.clone());
         let mut new_comp = new_comp.create_edge_io_split();
         decl.add_component(&new_comp);
-        //input_enabler::make_input_enabled(&mut new_comp, &decl);
 
         let new_system = Box::new(new_comp);
         assert!(refine::check_refinement(new_system.clone(), base_system.clone()).unwrap());

--- a/src/tests/save_component/save_comp_helper.rs
+++ b/src/tests/save_component/save_comp_helper.rs
@@ -4,6 +4,7 @@ pub mod save_comp_helper {
     use crate::DataReader::parse_queries;
     use crate::ModelObjects::representations::QueryExpression;
     use crate::System::extract_system_rep;
+    use crate::System::input_enabler;
     use crate::System::refine;
     use crate::System::save_component::combine_components;
     use crate::TransitionSystems::TransitionSystem;
@@ -22,7 +23,7 @@ pub mod save_comp_helper {
             panic!("Failed to create system")
         };
 
-        let new_comp = combine_components(&base_system.clone(), &decl.clone());
+        let new_comp = combine_components(&base_system.clone());
         let mut new_comp = Box::new(new_comp.create_edge_io_split());
         decl.add_component(&new_comp);
 
@@ -37,12 +38,8 @@ pub mod save_comp_helper {
 
         //Only do refinement check if both pass precheck
         if base_precheck && new_precheck {
-            assert!(
-                refine::check_refinement(new_comp.clone(), base_system.clone(), &decl).unwrap()
-            );
-            assert!(
-                refine::check_refinement(base_system.clone(), new_comp.clone(), &decl).unwrap()
-            );
+            assert!(refine::check_refinement(new_comp.clone(), base_system.clone()).unwrap());
+            assert!(refine::check_refinement(base_system.clone(), new_comp.clone()).unwrap());
         }
     }
 }


### PR DESCRIPTION
Specifically in the last commit i.e. c66450a some currently unused functions code were removed. These functions should be double checked for whether we need them later or not.