### PR TITLE
Added proper CLI result output

### DIFF
--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -259,3 +259,37 @@ pub enum QueryExpression {
     Bool(bool),
     Int(i32),
 }
+
+impl QueryExpression {
+    pub fn pretty_string(&self) -> String {
+        match self {
+            QueryExpression::Refinement(left, right) => format!(
+                "refinement: {} <= {}",
+                left.pretty_string(),
+                right.pretty_string()
+            ),
+            QueryExpression::Consistency(system) => {
+                format!("consistency: {}", system.pretty_string())
+            }
+            QueryExpression::GetComponent(comp) => {
+                format!("get-component: {}", comp.pretty_string())
+            }
+            QueryExpression::SaveAs(system, name) => {
+                format!("{} save-as {}", system.pretty_string(), name.clone())
+            }
+            QueryExpression::Conjunction(left, right) => {
+                format!("{} && {}", left.pretty_string(), right.pretty_string())
+            }
+            QueryExpression::Composition(left, right) => {
+                format!("{} || {}", left.pretty_string(), right.pretty_string())
+            }
+            QueryExpression::Quotient(left, right) => {
+                format!("{} \\\\ {}", left.pretty_string(), right.pretty_string())
+            }
+            QueryExpression::Parentheses(system) => format!("({})", system.pretty_string()),
+            QueryExpression::VarName(name) => name.clone(),
+
+            _ => panic!("Rule not implemented yet"),
+        }
+    }
+}

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -13,6 +13,33 @@ pub enum QueryResult {
     Error(String),
 }
 
+impl QueryResult {
+    pub fn print_result(&self, query_str: &str) {
+        match self {
+            QueryResult::Refinement(true) => satisfied(query_str),
+            QueryResult::Refinement(false) => not_satisfied(query_str),
+
+            QueryResult::Consistency(true) => satisfied(query_str),
+            QueryResult::Consistency(false) => not_satisfied(query_str),
+
+            QueryResult::Determinism(true) => satisfied(query_str),
+            QueryResult::Determinism(false) => not_satisfied(query_str),
+
+            QueryResult::Error(_) => println!("{} -- Failed", query_str),
+
+            _ => (),
+        };
+    }
+}
+
+fn satisfied(query_str: &str) {
+    println!("{} -- Property is satisfied", query_str);
+}
+
+fn not_satisfied(query_str: &str) {
+    println!("{} -- Property is NOT satisfied", query_str);
+}
+
 pub trait ExecutableQuery {
     fn execute(self: Box<Self>) -> QueryResult;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ pub fn main() {
         optimized_components.push(optimized_comp);
     }
 
+    let mut results = vec![];
     for query in &queries {
         let executable_query = Box::new(extract_system_rep::create_executable_query(
             query,
@@ -48,6 +49,13 @@ pub fn main() {
         if let QueryResult::Error(err) = result {
             panic!(err);
         }
+
+        results.push(result);
+    }
+
+    println!("\nQuery results:");
+    for index in 0..queries.len() {
+        results[index].print_result(&queries[index].query.as_ref().unwrap().pretty_string())
     }
 }
 


### PR DESCRIPTION
This PR adds a proper result to the CLI, and will be used when interfacing with the Ecdar GUI and Test framework

This PR tries to guarantee that a result summary is placed at the end in the same order as they query is provided.
`Query results:
refinement: A <= B -- Property is satisfied
consistency: A || B -- Property is Not satisfied`
following the form
`{query} -- {whether query is satisfied}`

If an error is occurred it will be denoted with "-- Failed"
