### PR TITLE
Zone initialization improvements

### DIFF
--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -1,5 +1,6 @@
 use crate::DBMLib::lib;
 use crate::ModelObjects::max_bounds::MaxBounds;
+use std::f64;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, std::cmp::PartialEq)]
@@ -9,19 +10,24 @@ pub struct Zone {
 }
 
 impl Zone {
-    pub fn from(vec: Vec<i32>, dim: u32) -> Self {
+    pub fn from(vec: Vec<i32>) -> Self {
+        let size = vec.len() as f64;
+        let dim = size.sqrt().floor() as u32;
         assert_eq!((dim * dim) as usize, vec.len());
 
-        Self {
+        let mut zone = Self {
             dimension: dim,
             matrix: vec,
-        }
+        };
+        zone.close();
+
+        zone
     }
 
     pub fn new(dimension: u32) -> Self {
         Self {
             dimension,
-            matrix: vec![0; (dimension * dimension) as usize],
+            matrix: vec![1; (dimension * dimension) as usize],
         }
     }
 
@@ -233,6 +239,10 @@ impl Zone {
         }
 
         true
+    }
+
+    pub fn close(&mut self) {
+        lib::rs_dbm_close(&mut self.matrix, self.dimension);
     }
 }
 

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -482,6 +482,12 @@ pub fn rs_dbm_add_EQ_const_constraint(
     }
 }
 
+pub fn rs_dbm_close(dbm: &mut [i32], dimension: u32) {
+    unsafe {
+        dbm_close(dbm.as_mut_ptr(), dimension);
+    }
+}
+
 /// Contrain DBM with two constraints both applied to the same variables.
 /// * DBM must be closed and non empty
 /// * dim > 1 induced by i < dim & j < dim & i != j

--- a/src/tests/dbm/zone.rs
+++ b/src/tests/dbm/zone.rs
@@ -5,17 +5,17 @@ mod test {
 
     #[test]
     fn testZoneValid1() {
-        assert!(Zone::from(vec![1, 1, lib::DBM_INF, 1], 2).is_valid());
+        assert!(Zone::from(vec![1, 1, lib::DBM_INF, 1]).is_valid());
     }
 
     #[test]
     fn testZoneValid2() {
-        assert!(Zone::from(vec![1, 1, 1, 1], 2).is_valid());
+        assert!(Zone::from(vec![1, 1, 1, 1]).is_valid());
     }
 
     #[test]
     fn testZoneValid3() {
-        assert!(Zone::from(vec![1, -3, 11, 1], 2).is_valid());
+        assert!(Zone::from(vec![1, -3, 11, 1]).is_valid());
     }
 
     #[test]
@@ -30,7 +30,7 @@ mod test {
 
     #[test]
     fn testZoneGetConstraint1() {
-        let zone = Zone::from(vec![1, -3, 11, 1], 2).clone();
+        let zone = Zone::from(vec![1, -3, 11, 1]).clone();
         assert_eq!(zone.get_constraint(0, 0), (false, 0));
         assert_eq!(zone.get_constraint(0, 1), (false, -2));
         assert_eq!(zone.get_constraint(1, 0), (false, 5));
@@ -62,5 +62,11 @@ mod test {
         zone2.add_lte_constraint(1, 0, 10);
 
         zone1.dbm_minus_dbm(&mut zone2);
+    }
+
+    #[test]
+    fn newDbm_isValid() {
+        let zone = Zone::new(2);
+        assert!(zone.is_valid());
     }
 }


### PR DESCRIPTION
This makes the `Zone::from` close a dbm making it easier to create a valid zone. Additionally it solves an issue where `Zone::new` would create invalid zones.