### PR TITLE
Changed code to operate on federations over zones

### DIFF
--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -319,7 +319,7 @@ impl Federation {
     }
 
     pub fn can_delay_indefinitely(&mut self) -> bool {
-        if self.zones.len() == 0 {
+        if self.is_empty() {
             return false;
         }
 

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -821,7 +821,7 @@ pub fn rs_dbm_boundbool2raw(bound: i32, is_strict: bool) -> i32 {
 pub fn rs_fed_extrapolate_max_bounds(
     federation: &mut Vec<*mut raw_t>,
     dim: u32,
-    max_bounds: &Vec<i32>,
+    max_bounds: &[i32],
 ) -> Federation {
     unsafe {
         let mut fed = dbm_fed_t::new(dim);

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -1,21 +1,32 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::{Federation, Zone};
 use crate::ModelObjects::component;
 use crate::ModelObjects::representations::BoolExpression;
 
 pub fn apply_constraints_to_state(
     guard: &BoolExpression,
-    decls: &component::Declarations,
-    zone: &mut Zone,
+    state: &mut component::State,
+    comp_index: usize,
 ) -> bool {
-    if let BoolExpression::Bool(val) = apply_constraints_to_state_helper(guard, decls, zone, true).0
-    {
+    apply_constraints_to_federation(
+        guard,
+        state.decorated_locations.get_decl(comp_index),
+        &mut state.federation,
+    )
+}
+
+pub fn apply_constraints_to_federation(
+    guard: &BoolExpression,
+    decls: &component::Declarations,
+    fed: &mut Federation,
+) -> bool {
+    if let BoolExpression::Bool(val) = apply_constraints_to_fed_helper(guard, decls, fed, true).0 {
         val
     } else {
-        panic!("unexpected value returned when attempting to apply constraints to zone")
+        panic!("unexpected value returned when attempting to apply constraints to federation")
     }
 }
 
-pub fn apply_constraints_to_state_declarations(
+pub fn apply_constraints_to_zone(
     guard: &BoolExpression,
     decls: &component::Declarations,
     zone: &mut Zone,
@@ -310,25 +321,29 @@ pub fn apply_constraints_to_state_helper(
         BoolExpression::Clock(index) => (BoolExpression::Clock(*index), false),
     }
 }
-pub fn apply_constraints_to_state2(
+
+pub fn apply_constraints_to_fed_helper(
     guard: &BoolExpression,
-    state: &mut component::State,
-    comp_index: usize,
-) -> BoolExpression {
+    decls: &component::Declarations,
+    fed: &mut Federation,
+    should_apply: bool,
+) -> (BoolExpression, bool) {
     match guard {
         BoolExpression::AndOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state, comp_index);
+            let (left, _contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, true);
             if let BoolExpression::Bool(val) = left {
                 if !val {
-                    return BoolExpression::Bool(false);
+                    return (BoolExpression::Bool(false), false);
                 }
             }
-            let right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (right, _contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, true);
 
             match left {
                 BoolExpression::Bool(left_val) => match right {
                     BoolExpression::Bool(right_val) => {
-                        return BoolExpression::Bool(left_val && right_val)
+                        (BoolExpression::Bool(left_val && right_val), false)
                     }
                     _ => {
                         panic!("expected bool in apply guard && expression")
@@ -340,12 +355,25 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::OrOp(left, right) => {
-            let left = apply_constraints_to_state2(&**left, state, comp_index);
-            let right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (mut left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (mut right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
 
+            if contains_clock_left && contains_clock_right {
+                panic!("clock constrained on both sides of or operator, resulting in state that is not well defined")
+            }
+
+            if contains_clock_left {
+                left = apply_constraints_to_fed_helper(&left, decls, fed, true).0;
+            } else if contains_clock_right {
+                right = apply_constraints_to_fed_helper(&right, decls, fed, true).0;
+            }
             match left {
                 BoolExpression::Bool(left_val) => match right {
-                    BoolExpression::Bool(right_val) => BoolExpression::Bool(left_val || right_val),
+                    BoolExpression::Bool(right_val) => {
+                        (BoolExpression::Bool(left_val || right_val), false)
+                    }
                     _ => {
                         panic!("expected bool in apply guard || expression")
                     }
@@ -356,18 +384,24 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::LessEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
-            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (computed_left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (computed_right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
 
+            if !should_apply && (contains_clock_right || contains_clock_left) {
+                return (BoolExpression::LessEQ(left.clone(), right.clone()), true);
+            }
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lte_constraint(left_index, right_index, 0);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(left_index, right_index, 0);
+
+                        (BoolExpression::Bool(result), false)
                     }
                     BoolExpression::Int(right_val) => {
-                        let result = state.zone.add_lte_constraint(left_index, 0, right_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(left_index, 0, right_val);
+                        (BoolExpression::Bool(result), false)
                     }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
@@ -375,10 +409,12 @@ pub fn apply_constraints_to_state2(
                 },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lte_constraint(0, right_index, -left_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(0, right_index, -left_val);
+                        (BoolExpression::Bool(result), false)
                     }
-                    BoolExpression::Int(right_val) => BoolExpression::Bool(left_val <= right_val),
+                    BoolExpression::Int(right_val) => {
+                        (BoolExpression::Bool(left_val <= right_val), false)
+                    }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
                     }
@@ -389,17 +425,24 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatEQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
-            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (computed_left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (computed_right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
+
+            if !should_apply && (contains_clock_right || contains_clock_left) {
+                return (BoolExpression::GreatEQ(left.clone(), right.clone()), true);
+            }
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lte_constraint(right_index, left_index, 0);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(right_index, left_index, 0);
+
+                        (BoolExpression::Bool(result), false)
                     }
                     BoolExpression::Int(right_val) => {
-                        let result = state.zone.add_lte_constraint(0, left_index, -right_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(0, left_index, -right_val);
+                        (BoolExpression::Bool(result), false)
                     }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
@@ -407,10 +450,12 @@ pub fn apply_constraints_to_state2(
                 },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lte_constraint(right_index, 0, left_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lte_constraint(right_index, 0, left_val);
+                        (BoolExpression::Bool(result), false)
                     }
-                    BoolExpression::Int(right_val) => BoolExpression::Bool(left_val >= right_val),
+                    BoolExpression::Int(right_val) => {
+                        (BoolExpression::Bool(left_val >= right_val), false)
+                    }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
                     }
@@ -420,19 +465,65 @@ pub fn apply_constraints_to_state2(
                 }
             }
         }
+        BoolExpression::EQ(left, right) => {
+            let (computed_left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (computed_right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
+
+            if !should_apply && (contains_clock_right || contains_clock_left) {
+                return (BoolExpression::GreatEQ(left.clone(), right.clone()), true);
+            }
+            match computed_left {
+                BoolExpression::Clock(left_index) => match computed_right {
+                    BoolExpression::Clock(right_index) => {
+                        let result = fed.add_eq_constraint(right_index, left_index);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    BoolExpression::Int(right_val) => {
+                        let result = fed.add_eq_const_constraint(left_index, right_val);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    _ => {
+                        panic!("invalid type in EQ expression in guard")
+                    }
+                },
+                BoolExpression::Int(left_val) => match computed_right {
+                    BoolExpression::Clock(right_index) => {
+                        let result = fed.add_eq_const_constraint(right_index, left_val);
+                        (BoolExpression::Bool(result), false)
+                    }
+                    BoolExpression::Int(right_val) => {
+                        (BoolExpression::Bool(left_val == right_val), false)
+                    }
+                    _ => {
+                        panic!("invalid type in EQ expression in guard")
+                    }
+                },
+                _ => {
+                    panic!("invalid type in EQ expression in guard")
+                }
+            }
+        }
         BoolExpression::LessT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
-            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (computed_left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (computed_right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
+
+            if !should_apply && (contains_clock_right || contains_clock_left) {
+                return (BoolExpression::LessT(left.clone(), right.clone()), true);
+            }
 
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lt_constraint(left_index, right_index, 0);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(left_index, right_index, 0);
+                        (BoolExpression::Bool(result), false)
                     }
                     BoolExpression::Int(right_val) => {
-                        let result = state.zone.add_lt_constraint(left_index, 0, right_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(left_index, 0, right_val);
+                        (BoolExpression::Bool(result), false)
                     }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
@@ -440,10 +531,12 @@ pub fn apply_constraints_to_state2(
                 },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lt_constraint(0, right_index, -left_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(0, right_index, -left_val);
+                        (BoolExpression::Bool(result), false)
                     }
-                    BoolExpression::Int(right_val) => BoolExpression::Bool(left_val <= right_val),
+                    BoolExpression::Int(right_val) => {
+                        (BoolExpression::Bool(left_val <= right_val), false)
+                    }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
                     }
@@ -454,17 +547,23 @@ pub fn apply_constraints_to_state2(
             }
         }
         BoolExpression::GreatT(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
-            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
+            let (computed_left, contains_clock_left) =
+                apply_constraints_to_fed_helper(&**left, decls, fed, false);
+            let (computed_right, contains_clock_right) =
+                apply_constraints_to_fed_helper(&**right, decls, fed, false);
+
+            if !should_apply && (contains_clock_right || contains_clock_left) {
+                return (BoolExpression::GreatT(left.clone(), right.clone()), true);
+            }
             match computed_left {
                 BoolExpression::Clock(left_index) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lt_constraint(right_index, left_index, 0);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(right_index, left_index, 0);
+                        (BoolExpression::Bool(result), false)
                     }
                     BoolExpression::Int(right_val) => {
-                        let result = state.zone.add_lt_constraint(0, left_index, -right_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(0, left_index, -right_val);
+                        (BoolExpression::Bool(result), false)
                     }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
@@ -472,10 +571,12 @@ pub fn apply_constraints_to_state2(
                 },
                 BoolExpression::Int(left_val) => match computed_right {
                     BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_lt_constraint(right_index, 0, left_val);
-                        BoolExpression::Bool(result)
+                        let result = fed.add_lt_constraint(right_index, 0, left_val);
+                        (BoolExpression::Bool(result), false)
                     }
-                    BoolExpression::Int(right_val) => BoolExpression::Bool(left_val >= right_val),
+                    BoolExpression::Int(right_val) => {
+                        (BoolExpression::Bool(left_val >= right_val), false)
+                    }
                     _ => {
                         panic!("invalid type in LEQ expression in guard")
                     }
@@ -485,59 +586,20 @@ pub fn apply_constraints_to_state2(
                 }
             }
         }
-        BoolExpression::Parentheses(expr) => apply_constraints_to_state2(expr, state, comp_index),
+        BoolExpression::Parentheses(expr) => {
+            apply_constraints_to_fed_helper(expr, decls, fed, should_apply)
+        }
         BoolExpression::VarName(name) => {
-            if let Some(clock_index) = state
-                .get_declarations(comp_index)
-                .get_clocks()
-                .get(name.as_str())
-            {
-                BoolExpression::Clock(*clock_index)
-            } else if let Some(val) = state
-                .get_declarations(comp_index)
-                .get_ints()
-                .get(name.as_str())
-            {
-                BoolExpression::Int(*val)
+            if let Some(clock_index) = decls.get_clocks().get(name.as_str()) {
+                (BoolExpression::Clock(*clock_index), true)
+            } else if let Some(val) = decls.get_ints().get(name.as_str()) {
+                (BoolExpression::Int(*val), false)
             } else {
-                panic!("no variable or clock named {:?}", name)
+                panic!("No clock or variable named {:?} was found", name)
             }
         }
-        BoolExpression::Bool(val) => BoolExpression::Bool(*val),
-        BoolExpression::Int(val) => BoolExpression::Int(*val),
-        BoolExpression::Clock(index) => BoolExpression::Clock(*index),
-        BoolExpression::EQ(left, right) => {
-            let computed_left = apply_constraints_to_state2(&**left, state, comp_index);
-            let computed_right = apply_constraints_to_state2(&**right, state, comp_index);
-
-            match computed_left {
-                BoolExpression::Clock(left_index) => match computed_right {
-                    BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_eq_constraint(right_index, left_index);
-                        BoolExpression::Bool(result)
-                    }
-                    BoolExpression::Int(right_val) => {
-                        let result = state.zone.add_eq_const_constraint(left_index, right_val);
-                        BoolExpression::Bool(result)
-                    }
-                    _ => {
-                        panic!("invalid type in EQ expression in guard")
-                    }
-                },
-                BoolExpression::Int(left_val) => match computed_right {
-                    BoolExpression::Clock(right_index) => {
-                        let result = state.zone.add_eq_const_constraint(right_index, left_val);
-                        BoolExpression::Bool(result)
-                    }
-                    BoolExpression::Int(right_val) => BoolExpression::Bool(left_val == right_val),
-                    _ => {
-                        panic!("invalid type in EQ expression in guard")
-                    }
-                },
-                _ => {
-                    panic!("invalid type in EQ expression in guard")
-                }
-            }
-        }
+        BoolExpression::Bool(val) => (BoolExpression::Bool(*val), false),
+        BoolExpression::Int(val) => (BoolExpression::Int(*val), false),
+        BoolExpression::Clock(index) => (BoolExpression::Clock(*index), false),
     }
 }

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -39,7 +39,7 @@ pub fn state_updater(
                     .get_declarations(comp_index)
                     .get_clock_index_by_name(update.get_variable_name())
                 {
-                    state.zone.update(clock_index, *val);
+                    state.federation.update(clock_index, *val);
                 } else {
                     panic!("Attempting to update a clock which is not initialized")
                 }

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::Federation;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
 use std::fmt::{Display, Formatter};
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter};
 pub struct StatePair<'a> {
     pub locations1: LocationTuple<'a>,
     pub locations2: LocationTuple<'a>,
-    pub zone: Zone,
+    pub federation: Federation,
 }
 
 impl<'b> StatePair<'b> {
@@ -16,19 +16,30 @@ impl<'b> StatePair<'b> {
         locations1: LocationTuple<'a>,
         locations2: LocationTuple<'a>,
     ) -> StatePair<'a> {
-        let mut zone = Zone::new(dimensions);
-        zone.zero();
-        zone.up();
+        let mut federation = Federation::zero(dimensions);
+        federation.up();
 
         StatePair {
             locations1,
             locations2,
-            zone,
+            federation,
         }
     }
 
+    pub fn extrapolate_max_bounds(&mut self, max_bounds: &MaxBounds) {
+        self.federation.extrapolate_max_bounds(max_bounds);
+    }
+
+    pub fn is_subset_eq(&mut self, other: &mut Self) -> bool {
+        self.federation.is_subset_eq(&mut other.federation)
+    }
+
+    pub fn delay(&mut self) {
+        self.federation.up();
+    }
+
     pub fn get_dimensions(&self) -> u32 {
-        self.zone.dimension
+        self.federation.dimension
     }
 
     pub fn get_locations1(&self) -> &LocationTuple<'b> {
@@ -39,15 +50,35 @@ impl<'b> StatePair<'b> {
         &self.locations2
     }
 
+    pub fn get_location(&self, is_states1: bool) -> &LocationTuple<'b> {
+        if is_states1 {
+            &self.locations1
+        } else {
+            &self.locations2
+        }
+    }
+
     //Used to allow borrowing both states as mutable
     pub fn get_mut_states(
         &mut self,
         is_states1: bool,
-    ) -> (&mut LocationTuple<'b>, &mut LocationTuple<'b>) {
+    ) -> (
+        &mut LocationTuple<'b>,
+        &mut LocationTuple<'b>,
+        &mut Federation,
+    ) {
         if is_states1 {
-            (&mut self.locations1, &mut self.locations2)
+            (
+                &mut self.locations1,
+                &mut self.locations2,
+                &mut self.federation,
+            )
         } else {
-            (&mut self.locations2, &mut self.locations1)
+            (
+                &mut self.locations2,
+                &mut self.locations1,
+                &mut self.federation,
+            )
         }
     }
 
@@ -64,7 +95,7 @@ impl<'b> StatePair<'b> {
         sys1: &TransitionSystemPtr,
         sys2: &TransitionSystemPtr,
     ) -> MaxBounds {
-        let dim = self.zone.dimension;
+        let dim = self.federation.dimension;
 
         let mut bounds = sys1.get_max_bounds(dim);
         bounds.add_bounds(&sys2.get_max_bounds(dim));
@@ -84,7 +115,11 @@ impl<'b> Display for StatePair<'b> {
             f.write_fmt(format_args!("{}, ", l.get_id()))?;
         }
         f.write_str("}}")?;
-        f.write_fmt(format_args!("Zone: {}", self.zone))?;
+
+        f.write_str("Zones:\n")?;
+        for zone in &self.federation.zones {
+            f.write_fmt(format_args!("{}\n", zone))?;
+        }
 
         Ok(())
     }

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -253,7 +253,7 @@ fn prepare_init_state(
     for (location, decl) in initial_locations_1.iter_zipped() {
         let init_inv1 = location.get_invariant();
         let init_inv1_success = if let Some(inv1) = init_inv1 {
-            apply_constraints_to_federation(&inv1, decl, &mut initial_pair.federation)
+            apply_constraints_to_federation(inv1, decl, &mut initial_pair.federation)
         } else {
             true
         };
@@ -265,7 +265,7 @@ fn prepare_init_state(
     for (location, decl) in initial_locations_2.iter_zipped() {
         let init_inv2 = location.get_invariant();
         let init_inv2_success = if let Some(inv2) = init_inv2 {
-            apply_constraints_to_federation(&inv2, decl, &mut initial_pair.federation)
+            apply_constraints_to_federation(inv2, decl, &mut initial_pair.federation)
         } else {
             true
         };

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -63,15 +63,16 @@ macro_rules! default_composition {
 
         fn get_initial_state(&self, dimensions: u32) -> State {
             let init_loc = self.get_initial_location();
-            let mut zone = Zone::init(dimensions);
-            if !init_loc.apply_invariants(&mut zone) {
+            let mut state = State {
+                decorated_locations: init_loc.clone(),
+                federation: Federation::zero(dimensions),
+            };
+            state.federation.up();
+
+            if !init_loc.apply_invariants_fed(&mut state.federation) {
                 panic!("Invalid starting state");
             }
-
-            State {
-                decorated_locations: init_loc,
-                zone,
-            }
+            state
         }
     };
 }

--- a/src/TransitionSystems/composition.rs
+++ b/src/TransitionSystems/composition.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::Federation;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;

--- a/src/TransitionSystems/conjunction.rs
+++ b/src/TransitionSystems/conjunction.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::Federation;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;

--- a/src/TransitionSystems/quotient.rs
+++ b/src/TransitionSystems/quotient.rs
@@ -1,4 +1,4 @@
-use crate::DBMLib::dbm::Zone;
+use crate::DBMLib::dbm::Federation;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;

--- a/src/tests/dbm/federation.rs
+++ b/src/tests/dbm/federation.rs
@@ -1,0 +1,122 @@
+#[cfg(test)]
+mod test {
+    use crate::DBMLib::dbm::{Federation, Zone};
+
+    #[test]
+    fn empty_federation_is_not_valid() {
+        let fed = Federation::empty(3);
+
+        assert!(!fed.is_valid());
+    }
+
+    #[test]
+    fn no_clocks_fed_equal_itself() {
+        let mut fed1 = Federation::full(1);
+        let mut fed2 = Federation::full(1);
+
+        assert!(fed1.is_subset_eq(&mut fed2));
+    }
+
+    #[test]
+    fn delayed_empty_federation_check_zone() {
+        let mut fed = Federation::zero(3);
+        fed.up();
+
+        let mut base_zone = Zone::new(3);
+        base_zone.up();
+
+        assert_eq!(fed.zones.len(), 1);
+
+        assert!(fed.zones[0].is_subset_eq(&base_zone));
+        assert!(base_zone.is_subset_eq(&fed.zones[0]));
+    }
+
+    #[test]
+    fn updated_full_federation_check_zone() {
+        let mut fed = Federation::full(3);
+        fed.update(2, 0);
+
+        let mut base_zone = Zone::init(3);
+        base_zone.update(2, 0);
+
+        assert_eq!(fed.zones.len(), 1);
+
+        assert!(fed.zones[0].is_subset_eq(&base_zone));
+        assert!(base_zone.is_subset_eq(&fed.zones[0]));
+    }
+
+    #[test]
+    fn full_federations_equals() {
+        let mut fed1 = Federation::full(3);
+        let mut fed2 = Federation::full(3);
+
+        assert!(fed1.is_subset_eq(&mut fed2));
+        assert!(fed2.is_subset_eq(&mut fed1));
+    }
+
+    #[test]
+    fn empty_is_subset_of_full_federation() {
+        let mut empty = Federation::empty(3);
+        let mut full = Federation::full(3);
+
+        assert!(empty.is_subset_eq(&mut full));
+        assert!(!full.is_subset_eq(&mut empty));
+    }
+
+    #[test]
+    fn full_can_delay_indefinitely() {
+        let mut full = Federation::full(3);
+
+        assert!(full.can_delay_indefinitely());
+    }
+
+    #[test]
+    fn delayed_zero_can_delay_indefinitely() {
+        let mut fed = Federation::zero(3);
+        fed.up();
+
+        assert!(fed.can_delay_indefinitely());
+    }
+
+    #[test]
+    fn empty_can_not_delay_indefinitely() {
+        let mut empty = Federation::empty(3);
+        assert!(!empty.can_delay_indefinitely());
+    }
+
+    #[test]
+    fn contrain_full_fed() {
+        let mut full = Federation::full(2);
+
+        println!("\n{}", full);
+        full.add_lt_constraint(0, 1, -20);
+
+        println!("\n{}", full);
+    }
+
+    #[test]
+    fn contrain_full_dbm() {
+        let mut full = Zone::init(2);
+
+        println!("\n{}", full);
+        full.add_lt_constraint(0, 1, -20);
+
+        println!("\n{}", full);
+    }
+
+    #[test]
+    fn cant_delay_with_upper_bound() {
+        let mut full = Federation::full(2);
+        full.add_lt_constraint(1, 0, 50);
+
+        assert!(!full.can_delay_indefinitely());
+    }
+
+    #[test]
+    fn can_delay_with_lower_bound() {
+        let mut full = Federation::full(2);
+        full.add_lt_constraint(0, 1, -50);
+
+        assert!(full.can_delay_indefinitely());
+    }
+}

--- a/src/tests/dbm/mod.rs
+++ b/src/tests/dbm/mod.rs
@@ -1,2 +1,3 @@
 pub mod dbm_basic;
+pub mod federation;
 pub mod zone;


### PR DESCRIPTION
This PR makes federations the primary driver for model checking with Reveaal.

Some tasks have been left open so we can focus on the communication instead these are:

- The federation calculations might be slow as we dont make proper use of the fed_t type from the library.
- Some operations that logically shouldnt require mutability still requires mutability
