### PR TITLE
Removed automatically updating dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ dbm-stub = []
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-clap = { git = "https://github.com/clap-rs/clap/", features=["yaml"] }
+clap = {version = "~2.34.0", features = ["yaml"]}
 boolean_expression = "0.3.10"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-pkg-config = {git = "https://github.com/rust-lang/pkg-config-rs.git"}
+pkg-config = "~0.3.22"
 generic-array = "0.14.4"
 lazy_static = "1.4.0"
 xml-rs = "0.8.3"


### PR DESCRIPTION
An error occurred because the cargo was setup to automatically take the newest version of clap from github. They're currently working on a new non released major version that deprecates how we use it causing build errors.

To fix this I put version numbers on all dependencies.
