### PR TITLE
Removed memory leak in dbm wrapper

### DIFF
--- a/dbm/wrapper.cpp
+++ b/dbm/wrapper.cpp
@@ -4,29 +4,27 @@
 #include "dbm/dbm.h"
 #include "hash/compute.h"
 
-
-
 extern "C"
 {
-raw_t dbm_boundbool2raw_wrapper(int32_t bound, bool isStrict)
-{
-    return (bound * 2) | (isStrict ^ 1);
-}
+    raw_t dbm_boundbool2raw_wrapper(int32_t bound, bool isStrict)
+    {
+        return (bound * 2) | (isStrict ^ 1);
+    }
 
-void dbm_zero_wrapper(raw_t* dbm, cindex_t dim)
-{
-    base_fill(dbm, dbm + (dim * dim), dbm_LE_ZERO);
-}
+    void dbm_zero_wrapper(raw_t *dbm, cindex_t dim)
+    {
+        base_fill(dbm, dbm + (dim * dim), dbm_LE_ZERO);
+    }
 
-int32_t dbm_raw2bound_wrapper(raw_t raw) { return (raw >> 1); }
-bool dbm_rawIsStrict_wrapper(raw_t raw) { return ((raw & 1) ^ dbm_WEAK); }
-bool dbm_satisfies_wrapper(const raw_t* dbm, cindex_t dim, cindex_t i, cindex_t j,
-                                 raw_t constraint)
-{
-    assert(dbm && dim && i < dim && j < dim && dim > 0);
-    return !(dbm[i * dim + j] > constraint &&             /* tightening ? */
-             dbm_negRaw(constraint) >= dbm[j * dim + i]); /* too tight ? */
-}
+    int32_t dbm_raw2bound_wrapper(raw_t raw) { return (raw >> 1); }
+    bool dbm_rawIsStrict_wrapper(raw_t raw) { return ((raw & 1) ^ dbm_WEAK); }
+    bool dbm_satisfies_wrapper(const raw_t *dbm, cindex_t dim, cindex_t i, cindex_t j,
+                               raw_t constraint)
+    {
+        assert(dbm && dim && i < dim && j < dim && dim > 0);
+        return !(dbm[i * dim + j] > constraint &&             /* tightening ? */
+                 dbm_negRaw(constraint) >= dbm[j * dim + i]); /* too tight ? */
+    }
 
     dbm::fed_t dbm_subtract1_exposed(const raw_t *arg1, const raw_t *arg2, cindex_t dim)
     {
@@ -64,7 +62,7 @@ bool dbm_satisfies_wrapper(const raw_t* dbm, cindex_t dim, cindex_t i, cindex_t 
 
     void dbm_vec_to_fed(raw_t *dbm[], cindex_t len, cindex_t dim, dbm::fed_t *fed_out)
     {
-        dbm::fed_t fed = (*new dbm::fed_t(dim));
+        dbm::fed_t fed(dim);
 
         for (int i = 0; i < len; i++)
         {
@@ -139,13 +137,13 @@ bool dbm_satisfies_wrapper(const raw_t* dbm, cindex_t dim, cindex_t i, cindex_t 
     void dbm_fed_minus_fed(raw_t *dbm1[], raw_t *dbm2[], cindex_t len1, cindex_t len2, cindex_t dim, dbm::fed_t *fed_out)
     {
 
-        dbm::fed_t fed1 = (*new dbm::fed_t(dim));
+        dbm::fed_t fed1(dim);
         for (int i = 0; i < len1; i++)
         {
             fed1.add(dbm1[i], dim);
         }
 
-        dbm::fed_t fed2 = (*new dbm::fed_t(dim));
+        dbm::fed_t fed2(dim);
         for (int i = 0; i < len2; i++)
         {
             fed2.add(dbm2[i], dim);

--- a/dbm/wrapper.cpp
+++ b/dbm/wrapper.cpp
@@ -62,13 +62,10 @@ extern "C"
 
     void dbm_vec_to_fed(raw_t *dbm[], cindex_t len, cindex_t dim, dbm::fed_t *fed_out)
     {
-        dbm::fed_t fed(dim);
-
         for (int i = 0; i < len; i++)
         {
-            fed.add(dbm[i], dim);
+            fed_out->add(dbm[i], dim);
         }
-        fed_out->add(fed);
     }
 
     int dbm_get_fed_size(dbm::fed_t *fed)
@@ -136,11 +133,9 @@ extern "C"
 
     void dbm_fed_minus_fed(raw_t *dbm1[], raw_t *dbm2[], cindex_t len1, cindex_t len2, cindex_t dim, dbm::fed_t *fed_out)
     {
-
-        dbm::fed_t fed1(dim);
         for (int i = 0; i < len1; i++)
         {
-            fed1.add(dbm1[i], dim);
+            fed_out->add(dbm1[i], dim);
         }
 
         dbm::fed_t fed2(dim);
@@ -149,9 +144,7 @@ extern "C"
             fed2.add(dbm2[i], dim);
         }
 
-        dbm::fed_t res = fed1 - fed2;
-
-        fed_out->add(res);
+        *fed_out -= fed2;
     }
 
     raw_t dbm_get_value(const raw_t *dbm, cindex_t dim, cindex_t i, cindex_t j)


### PR DESCRIPTION
While wokring on quotient i realized some heap allocations that were never freed. It turns out the allocated memory is only used in the local scope and therefore i turned it into a stack allocation instead.

Plus an unintended but welcome formatting aswell..