### PR TITLE
Input enable components when called over GRPC

### DIFF
--- a/src/ProtobufServer/ecdar_requests/update_components.rs
+++ b/src/ProtobufServer/ecdar_requests/update_components.rs
@@ -6,6 +6,7 @@ use crate::ModelObjects::component::Component;
 use crate::ProtobufServer::services::component::Rep;
 use crate::ProtobufServer::services::{Component as ProtobufComponent, ComponentsUpdateRequest};
 use crate::ProtobufServer::ConcreteEcdarBackend;
+use crate::System::input_enabler;
 use std::cell::RefCell;
 use tonic::{Request, Response};
 
@@ -59,6 +60,12 @@ fn save_components(component_container: &RefCell<ComponentContainer>, components
     for mut component in components {
         println!("Adding comp {} to container", component.get_name());
         component.create_edge_io_split();
+        let inputs: Vec<_> = component
+            .get_input_actions()
+            .into_iter()
+            .map(|channel| channel.name)
+            .collect();
+        input_enabler::make_input_enabled(&mut component, &inputs);
         component_container.borrow_mut().save_component(component);
     }
 }


### PR DESCRIPTION
Fixes #88 by input enabling components when they are added by update_component queries