### PR TITLE
Add static mutex to UDBM library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --skip "DBMLib::lib_dbm::UDBM::bindgen_test_layout_dbm_idbm_t" --test-threads 1
-
+          args: -- --skip "DBMLib::lib_dbm::UDBM::bindgen_test_layout_dbm_idbm_t"
   fmt:
     name: Check code is formatted
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [features]
 dbm-stub = []
 silent = []
+single-threaded = []
 
 [dependencies]
 serde_json = "1.0"

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -67,7 +67,7 @@ impl Display for Zone {
 
 #[derive(Debug)]
 pub struct Federation {
-    pub(in crate::DBMLib) raw: lib::fed_raw,
+    pub(in crate::DBMLib) raw: lib::FedRaw,
 }
 
 impl Federation {

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -43,6 +43,14 @@ unsafe fn syncw<T>(f: &mut dyn FnMut() -> T) -> T {
     f()
 }
 
+#[cfg(feature = "single-threaded")]
+macro_rules! sync {
+    ($arg:expr) => {
+        $arg
+    };
+}
+
+#[cfg(not(feature = "single-threaded"))]
 macro_rules! sync {
     ($arg:expr) => {
         syncw(&mut || $arg)

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -64,7 +64,7 @@ macro_rules! sync {
 
 pub const DBM_INF: i32 = i32::MAX - 1;
 
-pub type fed_raw = UDBM::dbm_fed_t;
+pub type FedRaw = UDBM::dbm_fed_t;
 
 /// used in input enabler to check if the constraint is strictly bound e.g strictly less than
 pub fn rs_raw_is_strict(raw: UDBM::raw_t) -> bool {

--- a/src/DBMLib/lib_dbm.rs
+++ b/src/DBMLib/lib_dbm.rs
@@ -1,8 +1,3 @@
-#![allow(non_snake_case)]
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
-
 macro_rules! trace {
     () => {{
         fn f() {}
@@ -18,15 +13,42 @@ macro_rules! trace {
 
 use crate::DBMLib::dbm::{Federation, Relation, Zone};
 use crate::ModelObjects::max_bounds::MaxBounds;
-use std::{mem, ptr, slice};
-
 use std::convert::TryInto;
+
 mod UDBM {
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(dead_code)]
+    #![allow(improper_ctypes)]
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
-//in DBM lib 0 is < and 1 is <=  here in regards to constraint_index parameter useds
-const LT: i32 = 0;
-const LTE: i32 = 1;
+
+use lazy_static::lazy_static; // 1.4.0
+use std::sync::{Mutex, RwLock};
+
+lazy_static! {
+    // static ref LIBRARY_LOCK: RwLock<()> = RwLock::new(());
+    static ref LIBRARY_LOCK: Mutex<i32> = Mutex::new(0);
+}
+
+/*
+unsafe fn syncr<T>(f: &mut dyn Fn() -> T) -> T {
+    let _l = LIBRARY_LOCK.read().unwrap();
+    f()
+}*/
+
+unsafe fn syncw<T>(f: &mut dyn FnMut() -> T) -> T {
+    let _l = LIBRARY_LOCK.lock().unwrap();
+    f()
+}
+
+macro_rules! sync {
+    ($arg:expr) => {
+        syncw(&mut || $arg)
+    };
+}
+
 pub const DBM_INF: i32 = i32::MAX - 1;
 
 pub type fed_raw = UDBM::dbm_fed_t;
@@ -37,694 +59,19 @@ const DEBUG: bool = false;
 /// If exceeded causes segmentation fault in c code
 const MAX_DIM: u32 = 128;
 
-/// Checks DBMS validity
-/// returns true or false
-///
-/// # Arguments
-///
-/// * `dbm` - A mutable pointer to an array, which will be the dbm
-/// * `dimension` - The dimension of the dbm
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// ```
-
-pub fn rs_dbm_is_valid(dbm: &UDBM::dbm_dbm_t, dimension: u32) -> bool {
-    trace!();
-    unsafe {
-        let res = UDBM::dbm_check_validity(dbm);
-
-        res
-    }
-}
-
-// pub fn rs_wrapped_dbm_is_valid(dbm: &mut[i32], dimension : u32) -> Result<bool, &'static str> {
-// trace!();
-//     match unsafe { let res = UDBM::dbm_isValid(dbm.as_mut_ptr(), dimension); } {
-//         res => Ok(true),
-//     }
-// }
-/// Initializes a DBM with
-/// * <= 0 on the diagonal and the first row
-/// * <= infinity elsewhere
-///
-/// # Arguments
-///
-/// * `dbm` - A mutable pointer to an array, which will be the dbm
-/// * `dimension` - The dimension of the dbm
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// ```
-pub fn rs_dbm_init(dbm: &mut [i32], dimension: u32) {
-    trace!();
-    unsafe {
-        UDBM::dbm_init(dbm.as_mut_ptr(), dimension);
-    }
-}
-
-/*
-/// Checks if `x_i - x_j < bound` is satisfied.
-/// It does not modify the DBM
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `bound` - The value which bounds the expression
-///
-/// # Return
-/// Bool indicating if the dbm satisfied the restriction
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_satisfies_i_LT_j(&mut dbm, 3, 1, 2, 10);
-/// ```
-pub fn rs_dbm_satisfies_i_LT_j(
-    dbm: &[i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    bound: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(bound, true);
-
-        let res = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_i,
-            var_index_j,
-            constraint,
-        );
-
-        res
-    }
-}
-
-/// Checks if `x_i - x_j <= bound` is satisfied.
-/// It does not modify the DBM
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `bound` - The value which bounds the expression
-///
-/// # Return
-/// Bool indicating if the dbm satisfied the restriction
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_satisfies_i_LTE_j(&mut dbm, 3, 1, 2, 10);
-/// ```
-pub fn rs_dbm_satisfies_i_LTE_j(
-    dbm: &[i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    bound: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(bound, false);
-
-        let res = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_i,
-            var_index_j,
-            constraint,
-        );
-
-        res
-    }
-}
-
-/// Checks if `x_i - x_j = 0` and `x_j - x_i = 0` is satisfied.
-/// It does not modify the DBM
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-///
-/// # Return
-/// Bool indicating if the dbm satisfied the restriction
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_satisfies_i_EQUAL_j(&mut dbm, 3, 1, 2);
-/// ```
-pub fn rs_dbm_satisfies_i_EQUAL_j(
-    dbm: &[i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(0, false);
-
-        let res_i_minus_j = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_i,
-            var_index_j,
-            constraint,
-        );
-        let res_j_minus_i = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_j,
-            var_index_i,
-            constraint,
-        );
-        return if res_i_minus_j && res_j_minus_i {
-            true
-        } else if (!res_i_minus_j && res_j_minus_i)
-            || (res_i_minus_j && !res_j_minus_i)
-            || (!res_i_minus_j && !res_j_minus_i)
-        {
-            false
-        } else {
-            panic!(
-                "Could not convert bool value from libary, found {:?} for i - j and {:?} for j - i",
-                res_i_minus_j, res_j_minus_i
-            )
-        };
-    }
-}
-
-/// Checks if `x_i - x_j = bound_j-bound_i` and `x_j - x_i = bound_i-bound_j` is satisfied.
-/// It does not modify the DBM
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `bound_i` - The value affecting the variable i
-/// * `bound_j` - The value affecting the variable j
-///
-/// # Return
-/// Bool indicating if the dbm satisfied the restriction
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_satisfies_i_EQUAL_j_bounds(&mut dbm, 3, 1, 2, 10, 4);
-/// ```
-pub fn rs_dbm_satisfies_i_EQUAL_j_bounds(
-    dbm: &[i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    bound_i: i32,
-    bound_j: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint_i_minus_j = UDBM::dbm_boundbool2raw_wrapper(bound_j - bound_i, false);
-        let constraint_j_minus_i = UDBM::dbm_boundbool2raw_wrapper(bound_i - bound_j, false);
-
-        let res_i_minus_j = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_i,
-            var_index_j,
-            constraint_i_minus_j,
-        );
-        let res_j_minus_i = UDBM::dbm_satisfies_wrapper(
-            dbm.as_ptr(),
-            dimension,
-            var_index_j,
-            var_index_i,
-            constraint_j_minus_i,
-        );
-        return if res_i_minus_j && res_j_minus_i {
-            true
-        } else if (!res_i_minus_j && res_j_minus_i)
-            || (res_i_minus_j && !res_j_minus_i)
-            || (!res_i_minus_j && !res_j_minus_i)
-        {
-            false
-        } else {
-            panic!(
-                "Could not convert bool value from libary, found {:?} for i - j and {:?} for j - i",
-                res_i_minus_j, res_j_minus_i
-            )
-        };
-    }
-}
-*/
-
-/// Contrain DBM with one constraint.
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `constraint` - Constraint for x_i - x_j to use
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// let constraint = UDBM::dbm_boundbool2raw(10, false);
-/// UDBM::dbm_constrain1(dbm.as_mut_ptr(), 3, 1, 0, constraint);
-/// ```
-pub fn rs_dbm_constrain1(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    constraint: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let res = UDBM::dbm_constrain1(
-            dbm.as_mut_ptr(),
-            dimension,
-            var_index_i,
-            var_index_j,
-            constraint,
-        );
-        return if true == res {
-            true
-        } else if false == res {
-            false
-        } else {
-            panic!("Could not convert bool value from libary, found {:?}", res)
-        };
-    }
-}
-
-/// Contrain DBM with one <= constraint based on the bound.
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `bound` - The value which bounds the expression
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```use regex::internal::Input;
-
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_add_LTE_constraint(dbm.as_mut_ptr(), 3, 1, 2, 3);
-/// ```
-pub fn rs_dbm_add_LTE_constraint(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    bound: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(bound, false);
-        rs_dbm_constrain1(dbm, dimension, var_index_i, var_index_j, constraint)
-    }
-}
-
-/// Contrain DBM with one < constraint based on the bound.
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `bound` - The value which bounds the expression
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_add_LT_constraint(dbm.as_mut_ptr(), 3, 1, 2, 3);
-/// ```
-pub fn rs_dbm_add_LT_constraint(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    bound: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(bound, true);
-
-        rs_dbm_constrain1(dbm, dimension, var_index_i, var_index_j, constraint)
-    }
-}
-
-/// Contrain DBM with one constraint based on the bound in both directions with bound 0.
-///
-/// `x_i-x_j <= 0` and `x_j-x_i <= 0`
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_add_EQ_constraint(dbm.as_mut_ptr(), 3, 1, 2);
-/// ```
-pub fn rs_dbm_add_EQ_constraint(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(0, false);
-
-        let res1 = rs_dbm_constrain1(dbm, dimension, var_index_i, var_index_j, constraint);
-        let res2 = rs_dbm_constrain1(dbm, dimension, var_index_j, var_index_i, constraint);
-        res1 && res2
-    }
-}
-
-/// Contrain DBM with one constraint based on the bound
-///
-/// `x_i-0 <= 5` and `0-x_i <= -5`
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index` - The index of the variable representing the ith element
-/// * `bound` - The constant bound the clock is set equal to
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-pub fn rs_dbm_add_EQ_const_constraint(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index: u32,
-    bound: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let constraint1 = UDBM::dbm_boundbool2raw_wrapper(bound, false);
-        let constraint2 = UDBM::dbm_boundbool2raw_wrapper(-bound, false);
-
-        let res1 = rs_dbm_constrain1(dbm, dimension, var_index, 0, constraint1);
-        let res2 = rs_dbm_constrain1(dbm, dimension, 0, var_index, constraint2);
-        res1 && res2
-    }
-}
-
-pub fn rs_dbm_close(dbm: &mut [i32], dimension: u32) {
-    trace!();
-    unsafe {
-        UDBM::dbm_close(dbm.as_mut_ptr(), dimension);
-    }
-}
-
-/// Contrain DBM with two constraints both applied to the same variables.
-/// * DBM must be closed and non empty
-/// * dim > 1 induced by i < dim & j < dim & i != j
-/// * as a consequence: i>=0 & j>=0 & i!=j => (i or j) > 0 and dim > (i or j) > 0 => dim > 1
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index_i` - The index of the variable representing the ith element
-/// * `var_index_j` - The index of the variable representing the jth element
-/// * `constraint1` - First constraint for x_i - x_j to use
-/// * `constraint2` - Second constraint for x_i - x_j to use
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// let constraint1 = UDBM::dbm_boundbool2raw(10, false);
-/// let constraint2 = UDBM::dbm_boundbool2raw(15, true);
-/// rs_dbm_add_and_constraint(dbm.as_mut_ptr(), 3, 1, 2, constraint1, constraint2);
-/// ```
-pub fn rs_dbm_add_and_constraint(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-    constraint1: i32,
-    constraint2: i32,
-) -> bool {
-    trace!();
-    let res1 = rs_dbm_constrain1(dbm, dimension, var_index_i, var_index_j, constraint1);
-    let res2 = rs_dbm_constrain1(dbm, dimension, var_index_i, var_index_j, constraint2);
-    res1 && res2
-}
-
-/// Constrain clock to == value, and return
-/// * if the result is non empty.
-///
-/// # Arguments
-///
-/// * `dbm` - The DBM
-/// * `dimension` - The dimension of the dbm
-/// * `var_index` - The index of the variable
-/// * `value` - the value to set the variable to
-///
-/// # Return
-/// Bool indicating if the constraint was applied sucessfully.
-///
-/// The resulting DBM is closed if it is non empty.
-///
-/// # Examples
-///
-/// ```
-/// let mut dbm : [i32; 9] = [0; 9];
-/// UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-/// rs_dbm_constrain_var_to_val(dbm.as_mut_ptr(), 3, 1, 0);
-/// ```
-pub fn rs_dbm_constrain_var_to_val(
-    dbm: &mut [i32],
-    dimension: u32,
-    var_index: u32,
-    value: i32,
-) -> bool {
-    trace!();
-    unsafe {
-        let res = UDBM::dbm_constrainClock(dbm.as_mut_ptr(), dimension, var_index, value);
-        return if true == res {
-            true
-        } else if false == res {
-            false
-        } else {
-            panic!("Could not convert bool value from libary, found {:?}", res)
-        };
-    }
-}
-
-pub fn rs_dbm_extrapolateMaxBounds(dbm1: &mut [i32], dim: u32, maxbounds: *const i32) {
-    trace!();
-    unsafe { UDBM::dbm_extrapolateMaxBounds(dbm1.as_mut_ptr(), dim, maxbounds) }
-}
-/*
-pub fn rs_dbm_get_constraint(
-    dbm: &[i32],
-    dimension: u32,
-    var_index_i: u32,
-    var_index_j: u32,
-) -> raw_t {
-    //trace!();
-    unsafe {
-        return UDBM::dbm_get_value(dbm.as_ptr(), dimension, var_index_i, var_index_j);
-    }
-}*/
-
 /// used in input enabler to check if the constraint is strictly bound e.g strictly less than
 pub fn rs_raw_is_strict(raw: UDBM::raw_t) -> bool {
-    //trace!();
     unsafe { UDBM::dbm_rawIsStrict_wrapper(raw) }
 }
 
 ///converts the bound from c++ to an usable rust type - used when input enabling
 pub fn rs_raw_to_bound(raw: UDBM::raw_t) -> i32 {
-    //trace!();
     unsafe { UDBM::dbm_raw2bound_wrapper(raw) }
 }
 
-/*
-/// test function taken from Jecdar
-pub fn libtest() {
-    let mut intArr = [0, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut intArr2 = [0, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut arr2 = [1, 1, 2147483646, 1];
-    let dbm = &mut intArr;
-    let dbm2 = &mut intArr2;
-    unsafe {
-        println!("dbm before init: {:?}", dbm);
-        UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-        println!("dbm after init: {:?}", dbm);
-
-        UDBM::dbm_init(dbm2.as_mut_ptr(), 3);
-
-        UDBM::dbm_init(arr2.as_mut_ptr(), 2);
-        println!("dbm 2 after init: {:?}", arr2);
-
-        let _testbool = UDBM::dbm_constrain1(arr2.as_mut_ptr(), 2, 1, 0, 5);
-        println!("{:?}", arr2);
-
-        let _testbool = UDBM::dbm_constrain1(arr2.as_mut_ptr(), 2, 0, 1, -2);
-        println!("{:?}", arr2);
-
-        UDBM::dbm_updateValue(arr2.as_mut_ptr(), 2, 1, 0);
-
-        println!("{:?}", arr2);
-
-        let raw = 3;
-
-        let bound = UDBM::dbm_raw2bound_wrapper(raw);
-        println!("raw: {:?}, bound: {:?}", raw, bound);
-
-        UDBM::dbm_zero_wrapper(arr2.as_mut_ptr(), 2);
-        println!("{:?}", arr2);
-
-        println!("dbm before constraint: {:?}", dbm);
-
-        let constraint = UDBM::dbm_boundbool2raw_wrapper(0, true);
-
-        rs_dbm_constrain1(dbm, 3, 1, 2, constraint);
-
-        println!("dbm after constraint: {:?}", dbm);
-
-        let res = rs_dbm_satisfies_i_LT_j(dbm, 3, 2, 1, 0);
-
-        println!("Result of satisfies check: {:?}", res);
-    }
-}
-
-/// test function taken from Jecdar
-pub fn libtest2() {
-    unsafe {
-        let mut dbm: [i32; 9] = [0; 9];
-        UDBM::dbm_init(dbm.as_mut_ptr(), 3);
-        println!("{:?}", dbm);
-
-        rs_dbm_satisfies_i_LT_j(&mut dbm, 3, 1, 2, 10);
-
-        UDBM::dbm_constrain1(dbm.as_mut_ptr(), 3, 1, 0, 3);
-        println!("{:?}", dbm);
-
-        UDBM::dbm_constrain1(dbm.as_mut_ptr(), 3, 2, 0, 2);
-        println!("{:?}", dbm);
-
-        UDBM::dbm_updateValue(dbm.as_mut_ptr(), 3, 1, 0);
-        println!("{:?}", dbm);
-
-        UDBM::dbm_up(dbm.as_mut_ptr(), 3);
-        println!("{:?}", dbm);
-    }
-}*/
-
-pub fn rs_dbm_boundbool2raw(bound: i32, is_strict: bool) -> i32 {
-    trace!();
+fn rs_bound_strict_to_raw(bound: i32, is_strict: bool) -> UDBM::raw_t {
     unsafe { UDBM::dbm_boundbool2raw_wrapper(bound, is_strict) }
 }
-
-/*
-fn rs_zone_from_dbm(dbm_ptr: UDBM::dbm_dbm_t, dim: u32) -> Zone {
-    trace!();
-    let mut zone_vec = Vec::with_capacity((dim * dim) as usize);
-    for i in 0..dim {
-        for j in 0..dim {
-            zone_vec.push(unsafe { UDBM::dbm_get_value(&dbm_ptr, i, j) }.clone())
-        }
-    }
-
-    Zone {
-        matrix: zone_vec,
-        dimension: dim,
-    }
-}*/
 
 /* BEGIN FEDERATION METHODS*/
 
@@ -741,7 +88,11 @@ pub fn rs_fed_get_zones(fed: &Federation) -> Vec<Zone> {
     }
     let mut out = Vec::<UDBM::raw_t>::with_capacity(len);
     unsafe {
-        UDBM::fed_get_dbm_vec(&fed.raw, out.as_mut_ptr(), len as u64);
+        sync!(UDBM::fed_get_dbm_vec(
+            &fed.raw,
+            out.as_mut_ptr(),
+            len as u64
+        ));
         out.set_len(len);
     }
 
@@ -757,7 +108,7 @@ pub fn rs_fed_get_zones(fed: &Federation) -> Vec<Zone> {
 pub fn rs_fed_intersect(fed1: &mut Federation, fed2: &Federation) {
     trace!();
     unsafe {
-        UDBM::fed_intersection(&mut fed1.raw, &fed2.raw);
+        sync!(UDBM::fed_intersection(&mut fed1.raw, &fed2.raw));
     }
     //rs_fed_reduce(&mut fed1, true);
 }
@@ -767,7 +118,7 @@ pub fn rs_fed_subtract(fed1: &mut Federation, fed2: &Federation) {
     trace!();
     //let mut result = fed1.clone();
     unsafe {
-        UDBM::fed_subtraction(&mut fed1.raw, &fed2.raw);
+        sync!(UDBM::fed_subtraction(&mut fed1.raw, &fed2.raw));
     }
     //May want to only do this optionally/not expensively?
     rs_fed_reduce(fed1, true);
@@ -775,39 +126,39 @@ pub fn rs_fed_subtract(fed1: &mut Federation, fed2: &Federation) {
 
 pub fn rs_fed_is_valid(fed: &Federation) -> bool {
     trace!();
-    unsafe { !UDBM::fed_is_empty(&fed.raw) }
+    unsafe { !sync!(UDBM::fed_is_empty(&fed.raw)) }
 }
 
 pub fn rs_fed_is_empty(fed: &Federation) -> bool {
     trace!();
-    unsafe { UDBM::fed_is_empty(&fed.raw) }
+    unsafe { sync!(UDBM::fed_is_empty(&fed.raw)) }
 }
 
 pub fn rs_fed_up(fed: &mut Federation) {
     trace!();
     unsafe {
-        UDBM::fed_up(&mut fed.raw);
+        sync!(UDBM::fed_up(&mut fed.raw));
     };
 }
 
 pub fn rs_fed_down(fed: &mut Federation) {
     trace!();
     unsafe {
-        UDBM::fed_down(&mut fed.raw);
+        sync!(UDBM::fed_down(&mut fed.raw));
     };
 }
 
 pub fn rs_fed_init(fed: &mut Federation) {
     trace!();
     unsafe {
-        UDBM::fed_init(&mut fed.raw);
+        sync!(UDBM::fed_init(&mut fed.raw));
     };
 }
 
 pub fn rs_fed_zero(fed: &mut Federation) {
     trace!();
     unsafe {
-        UDBM::fed_zero(&mut fed.raw);
+        sync!(UDBM::fed_zero(&mut fed.raw));
     };
 }
 
@@ -818,14 +169,7 @@ pub fn rs_fed_new(dim: UDBM::cindex_t) -> Federation {
     // Max dim from dbm\build\UDBM\src\udbm\dbm\DBMAllocator.h:32:35
     // If exceeded causes segmentation fault in c code
     assert!(dim < MAX_DIM);
-
-    let raw = unsafe {
-        UDBM::dbm_fed_t::new(dim)
-        //UDBM::fed_new(dim)
-        /*let mut ptr = ::std::mem::MaybeUninit::uninit();
-        UDBM::fed_new(ptr.as_mut_ptr(), dim);
-        ptr.assume_init()*/
-    };
+    let raw = unsafe { sync!(UDBM::dbm_fed_t::new(dim)) };
     Federation { raw }
 }
 
@@ -852,7 +196,15 @@ pub fn rs_fed_constrain(
     bound: i32,
     isStrict: bool,
 ) -> bool {
-    unsafe { UDBM::fed_constrain(&mut fed.raw, var_index_i, var_index_j, bound, isStrict) }
+    unsafe {
+        sync!(UDBM::fed_constrain(
+            &mut fed.raw,
+            var_index_i,
+            var_index_j,
+            bound,
+            isStrict
+        ))
+    }
 }
 
 /// Contrain Federation with one <= constraint based on the bound.
@@ -921,7 +273,7 @@ pub fn rs_fed_add_LT_constraint(
 ///
 pub fn rs_fed_add_EQ_constraint(fed: &mut Federation, var_index_i: u32, var_index_j: u32) -> bool {
     trace!();
-    let constraint = unsafe { UDBM::dbm_boundbool2raw_wrapper(0, false) };
+    let constraint = rs_bound_strict_to_raw(0, false);
     let res1 = rs_fed_constrain(fed, var_index_i, var_index_j, 0, false);
     let res2 = rs_fed_constrain(fed, var_index_j, var_index_i, 0, false);
     res1 && res2
@@ -956,30 +308,30 @@ pub fn rs_fed_update_clock(fed: &mut Federation, x: UDBM::cindex_t, v: i32) {
 pub fn rs_fed_update(fed: &mut Federation, x: UDBM::cindex_t, y: UDBM::cindex_t, v: i32) {
     trace!();
     unsafe {
-        UDBM::fed_update(&mut fed.raw, x, y, v);
+        sync!(UDBM::fed_update(&mut fed.raw, x, y, v));
     }
 }
 
 pub fn rs_fed_free_clock(fed: &mut Federation, x: UDBM::cindex_t) {
     trace!();
     unsafe {
-        UDBM::fed_free_clock(&mut fed.raw, x);
+        sync!(UDBM::fed_free_clock(&mut fed.raw, x));
     }
 }
 
 pub fn rs_fed_subset_eq(fed1: &Federation, fed2: &Federation) -> bool {
     trace!();
-    unsafe { UDBM::fed_subset_eq(&fed1.raw, &fed2.raw) }
+    unsafe { sync!(UDBM::fed_subset_eq(&fed1.raw, &fed2.raw)) }
 }
 
 pub fn rs_fed_intersects(fed1: &Federation, fed2: &Federation) -> bool {
     trace!();
-    unsafe { UDBM::fed_intersects(&fed1.raw, &fed2.raw) }
+    unsafe { sync!(UDBM::fed_intersects(&fed1.raw, &fed2.raw)) }
 }
 
 pub fn rs_fed_relation(fed1: &Federation, fed2: &Federation) -> Relation {
     trace!();
-    let rel: UDBM::relation_t = unsafe { UDBM::fed_relation(&fed1.raw, &fed2.raw, true) };
+    let rel: UDBM::relation_t = unsafe { sync!(UDBM::fed_relation(&fed1.raw, &fed2.raw, true)) };
 
     match rel {
         0 => Relation::Different,
@@ -992,26 +344,29 @@ pub fn rs_fed_relation(fed1: &Federation, fed2: &Federation) -> Relation {
 
 pub fn rs_fed_equals(fed1: &Federation, fed2: &Federation) -> bool {
     trace!();
-    unsafe { UDBM::fed_eq(&fed1.raw, &fed2.raw, true) }
+    unsafe { sync!(UDBM::fed_eq(&fed1.raw, &fed2.raw, true)) }
 }
 
 pub fn rs_fed_reduce(fed: &mut Federation, expensive: bool) {
     trace!();
     unsafe {
-        UDBM::fed_reduce(&mut fed.raw, expensive);
+        sync!(UDBM::fed_reduce(&mut fed.raw, expensive));
     }
 }
 
 pub fn rs_fed_can_delay_indef(fed: &Federation) -> bool {
     trace!();
-    unsafe { UDBM::fed_can_delay_indef(&fed.raw) }
+    unsafe { sync!(UDBM::fed_can_delay_indef(&fed.raw)) }
 }
 
 pub fn rs_fed_extrapolate_max_bounds(fed: &mut Federation, bounds: &MaxBounds) {
     trace!();
     assert_eq!(fed.get_dimensions(), bounds.get_dimensions());
     unsafe {
-        UDBM::fed_extrapolate_max_bounds(&mut fed.raw, bounds.clock_bounds.as_ptr());
+        sync!(UDBM::fed_extrapolate_max_bounds(
+            &mut fed.raw,
+            bounds.clock_bounds.as_ptr()
+        ));
     }
 }
 
@@ -1019,46 +374,43 @@ pub fn rs_fed_add_fed(fed: &mut Federation, other: &Federation) {
     trace!();
     assert_eq!(fed.get_dimensions(), other.get_dimensions());
     unsafe {
-        UDBM::fed_add_fed(&mut fed.raw, &other.raw);
+        sync!(UDBM::fed_add_fed(&mut fed.raw, &other.raw));
     }
 }
 
 pub fn rs_fed_invert(fed: &mut Federation) {
     trace!();
     unsafe {
-        UDBM::fed_invert(&mut fed.raw);
+        sync!(UDBM::fed_invert(&mut fed.raw));
     }
 }
 
 pub fn rs_fed_size(fed: &Federation) -> usize {
     trace!();
-    unsafe { UDBM::fed_size(&fed.raw) }.try_into().unwrap()
+    unsafe { sync!(UDBM::fed_size(&fed.raw)) }
+        .try_into()
+        .unwrap()
 }
 
 pub unsafe fn rs_fed_destruct(fed: &mut Federation) {
-    //fed.raw.nil();
-    //fed.raw.destruct();
-    UDBM::fed_destruct(&mut fed.raw);
+    sync!(UDBM::fed_destruct(&mut fed.raw));
 }
 
 pub fn rs_fed_copy(fed: &Federation) -> Federation {
     trace!();
-    let raw = unsafe {
-        UDBM::dbm_fed_t::new1(&fed.raw)
-        //UDBM::fed_copy(&fed.raw)
-    };
+    let raw = unsafe { sync!(UDBM::dbm_fed_t::new1(&fed.raw)) };
     Federation { raw }
 }
 
 pub fn rs_fed_dimensions(fed: &Federation) -> UDBM::cindex_t {
     trace!();
-    unsafe { UDBM::fed_dimension(&fed.raw) }
+    unsafe { sync!(UDBM::fed_dimension(&fed.raw)) }
 }
 
 /*
 pub fn rs_crash(dim: u32) {
     unsafe {
-        UDBM::fed_crash(dim);
+        sync!( UDBM::fed_crash(dim));
     }
 }*/
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn start_using_cli(matches: &clap::ArgMatches) {
         let result = executable_query.execute();
 
         if let QueryResult::Error(err) = result {
-            panic!(err);
+            panic!("{}", err);
         }
 
         results.push(result);


### PR DESCRIPTION
The static mutex allows us to have multithreaded rust code without having to worry about calling the UDBM library incorrectly (UDBM/UCDD is not thread safe). The mutex is aquired in `lib_dbm.rs` whenever a function _may_ change the internal state of the UDBM library. 
This also allows us to run `cargo test` without worrying about the number of test threads.

Optionally the mutex can be disabled statically with the new `single-threaded` feature.

In the future we may be able to use a `RwLock` instead of a `Mutex` so that multiple threads can read the internal state at once, but we can't really be sure which methods modify the internal state. Fx. the copy constructor of a federation increases a reference counter, which is not thread safe.