### PR TITLE
Refactor the results refactor to use Anyhow results instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ dbm-stub = []
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-clap = { git = "https://github.com/clap-rs/clap/", features=["yaml"] }
+clap = {version = "~2.34.0", features = ["yaml"]}
 boolean_expression = "0.3.10"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-pkg-config = {git = "https://github.com/rust-lang/pkg-config-rs.git"}
+pkg-config = "~0.3.22"
 generic-array = "0.14.4"
 lazy_static = "1.4.0"
 xml-rs = "0.8.3"
@@ -27,6 +27,7 @@ prost = "0.8.*"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 colored = "2.0.0"
 simple-error = "0.2.3"
+anyhow = { version = "1.0", features = ["std"] }
 
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ tonic = "0.5.*"
 prost = "0.8.*"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 colored = "2.0.0"
-simple-error = "0.2.3"
-anyhow = { version = "1.0", features = ["std"] }
+anyhow = { version = "1.0", features = ["std", "backtrace"] }
 
 
 [build-dependencies]

--- a/src/DBMLib/dbm.rs
+++ b/src/DBMLib/dbm.rs
@@ -1,11 +1,11 @@
+use crate::bail;
 use crate::DBMLib::lib;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::representations::BoolExpression;
 use crate::System::input_enabler::build_guard_from_zone;
+use anyhow::Result;
 use colored::Colorize;
-use simple_error::bail;
 use std::collections::HashMap;
-use std::error::Error;
 use std::f64;
 use std::fmt::{Display, Formatter};
 
@@ -350,7 +350,7 @@ impl Federation {
     pub fn as_boolexpression(
         &self,
         clocks: &HashMap<String, u32>,
-    ) -> Result<Option<BoolExpression>, Box<dyn Error>> {
+    ) -> Result<Option<BoolExpression>> {
         if self.num_zones() > 1 {
             bail!("Implementation cannot handle disjunct invariants")
         }

--- a/src/DataReader/component_loader.rs
+++ b/src/DataReader/component_loader.rs
@@ -1,5 +1,5 @@
 use crate::component::Component;
-use crate::open;
+use crate::context;
 use crate::DataReader::json_reader;
 use crate::DataReader::json_writer::component_to_json_file;
 use crate::DataReader::xml_parser::parse_xml_from_file;
@@ -22,7 +22,7 @@ pub struct ComponentContainer {
 
 impl ComponentLoader for ComponentContainer {
     fn get_component(&mut self, component_name: &str) -> Result<&Component> {
-        open!(
+        context!(
             self.loaded_components.get(component_name),
             "The component '{}' could not be retrieved",
             component_name
@@ -58,7 +58,7 @@ impl ComponentLoader for JsonProjectLoader {
             self.load_component(component_name)?;
         }
 
-        open!(
+        context!(
             self.loaded_components.get(component_name),
             "The component '{}' could not be retrieved",
             component_name
@@ -139,7 +139,7 @@ pub struct XmlProjectLoader {
 
 impl ComponentLoader for XmlProjectLoader {
     fn get_component(&mut self, component_name: &str) -> Result<&Component> {
-        open!(
+        context!(
             self.loaded_components.get(component_name),
             "The component '{}' could not be retrieved",
             component_name

--- a/src/DataReader/component_loader.rs
+++ b/src/DataReader/component_loader.rs
@@ -1,5 +1,5 @@
-use crate::bail;
 use crate::component::Component;
+use crate::open;
 use crate::DataReader::json_reader;
 use crate::DataReader::json_writer::component_to_json_file;
 use crate::DataReader::xml_parser::parse_xml_from_file;
@@ -22,11 +22,11 @@ pub struct ComponentContainer {
 
 impl ComponentLoader for ComponentContainer {
     fn get_component(&mut self, component_name: &str) -> Result<&Component> {
-        if let Some(component) = self.loaded_components.get(component_name) {
-            Ok(&component)
-        } else {
-            bail!("The component '{}' could not be retrieved", component_name);
-        }
+        open!(
+            self.loaded_components.get(component_name),
+            "The component '{}' could not be retrieved",
+            component_name
+        )
     }
     fn save_component(&mut self, component: Component) {
         self.unload_component(&component.name);
@@ -58,11 +58,11 @@ impl ComponentLoader for JsonProjectLoader {
             self.load_component(component_name)?;
         }
 
-        if let Some(component) = self.loaded_components.get(component_name) {
-            Ok(&component)
-        } else {
-            bail!("The component '{}' could not be retrieved", component_name);
-        }
+        open!(
+            self.loaded_components.get(component_name),
+            "The component '{}' could not be retrieved",
+            component_name
+        )
     }
 
     fn save_component(&mut self, component: Component) {
@@ -139,11 +139,11 @@ pub struct XmlProjectLoader {
 
 impl ComponentLoader for XmlProjectLoader {
     fn get_component(&mut self, component_name: &str) -> Result<&Component> {
-        if let Some(component) = self.loaded_components.get(component_name) {
-            Ok(&component)
-        } else {
-            bail!("The component '{}' could not be retrieved", component_name);
-        }
+        open!(
+            self.loaded_components.get(component_name),
+            "The component '{}' could not be retrieved",
+            component_name
+        )
     }
 
     fn save_component(&mut self, _: Component) {

--- a/src/DataReader/json_reader.rs
+++ b/src/DataReader/json_reader.rs
@@ -1,9 +1,9 @@
 use crate::ModelObjects::component;
 use crate::ModelObjects::queries;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
+use crate::{bail, info};
 use anyhow::Result;
 use serde::de::DeserializeOwned;
-use crate::bail;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -19,14 +19,10 @@ pub fn read_system_declarations(project_path: &str) -> Result<SystemDeclarations
         bail!("No system declarations in project");
     }
 
-    match read_json::<SystemDeclarations>(&sysdecl_path) {
-        Ok(sys_decls) => Ok(sys_decls),
-        Err(error) => bail!(
-            "We got error {}, and could not parse json file {} to component",
-            error,
-            &sysdecl_path
-        ),
-    }
+    info!(
+        read_json::<SystemDeclarations>(&sysdecl_path),
+        "Could not parse json file {} to component", &sysdecl_path
+    )
 }
 
 pub fn read_json_component(
@@ -70,12 +66,8 @@ pub fn read_queries(project_path: &str) -> Result<Vec<queries::Query>> {
         bail!("No queries file found for xml project");
     }
 
-    match read_json(&queries_path) {
-        Ok(json) => Ok(json),
-        Err(error) => bail!(
-            "We got error {}, and could not parse json file {} to query",
-            error,
-            &queries_path
-        ),
-    }
+    info!(
+        read_json(&queries_path),
+        "Could not parse json file {} to query", &queries_path
+    )
 }

--- a/src/DataReader/json_reader.rs
+++ b/src/DataReader/json_reader.rs
@@ -1,14 +1,14 @@
 use crate::ModelObjects::component;
 use crate::ModelObjects::queries;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
+use anyhow::Result;
 use serde::de::DeserializeOwned;
-use simple_error::bail;
-use std::error::Error;
+use crate::bail;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-pub fn read_system_declarations(project_path: &str) -> Result<SystemDeclarations, Box<dyn Error>> {
+pub fn read_system_declarations(project_path: &str) -> Result<SystemDeclarations> {
     let sysdecl_path = format!(
         "{}{}SystemDeclarations.json",
         project_path,
@@ -32,7 +32,7 @@ pub fn read_system_declarations(project_path: &str) -> Result<SystemDeclarations
 pub fn read_json_component(
     project_path: &str,
     component_name: &str,
-) -> Result<component::Component, Box<dyn Error>> {
+) -> Result<component::Component> {
     let component_path = format!(
         "{0}{1}Components{1}{2}.json",
         project_path,
@@ -46,7 +46,7 @@ pub fn read_json_component(
 //Input:File name
 //Description:uses the filename to open the file and then reads the file.
 //Output: Result type, if more info about this type is need please go to: https://doc.rust-lang.org/std/result/
-pub fn read_json<T: DeserializeOwned>(filename: &str) -> Result<T, Box<dyn Error>> {
+pub fn read_json<T: DeserializeOwned>(filename: &str) -> Result<T> {
     let mut file = File::open(filename)?;
     let mut data = String::new();
     file.read_to_string(&mut data)?;
@@ -56,14 +56,14 @@ pub fn read_json<T: DeserializeOwned>(filename: &str) -> Result<T, Box<dyn Error
     Ok(json_file)
 }
 
-pub fn json_to_component(json_str: &str) -> Result<component::Component, Box<dyn Error>> {
+pub fn json_to_component(json_str: &str) -> Result<component::Component> {
     Ok(serde_json::from_str(json_str)?)
 }
 
 //Input:Filename
 //Description: transforms json into query type
 //Output:Result
-pub fn read_queries(project_path: &str) -> Result<Vec<queries::Query>, Box<dyn Error>> {
+pub fn read_queries(project_path: &str) -> Result<Vec<queries::Query>> {
     let queries_path = format!("{}{}Queries.json", project_path, std::path::MAIN_SEPARATOR);
 
     if !Path::new(&queries_path).exists() {

--- a/src/DataReader/json_reader.rs
+++ b/src/DataReader/json_reader.rs
@@ -1,7 +1,7 @@
 use crate::ModelObjects::component;
 use crate::ModelObjects::queries;
 use crate::ModelObjects::system_declarations::SystemDeclarations;
-use crate::{bail, info};
+use crate::{bail, context};
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use std::fs::File;
@@ -19,9 +19,10 @@ pub fn read_system_declarations(project_path: &str) -> Result<SystemDeclarations
         bail!("No system declarations in project");
     }
 
-    info!(
+    context!(
         read_json::<SystemDeclarations>(&sysdecl_path),
-        "Could not parse json file {} to component", &sysdecl_path
+        "Could not parse json file {} to component",
+        &sysdecl_path
     )
 }
 
@@ -66,8 +67,9 @@ pub fn read_queries(project_path: &str) -> Result<Vec<queries::Query>> {
         bail!("No queries file found for xml project");
     }
 
-    info!(
+    context!(
         read_json(&queries_path),
-        "Could not parse json file {} to query", &queries_path
+        "Could not parse json file {} to query",
+        &queries_path
     )
 }

--- a/src/DataReader/json_writer.rs
+++ b/src/DataReader/json_writer.rs
@@ -1,4 +1,4 @@
-use crate::bail;
+use crate::info;
 use crate::ModelObjects::component::Component;
 use anyhow::Result;
 use std::fs::File;
@@ -16,11 +16,9 @@ pub fn component_to_json_file(project_path: &str, component: &Component) {
 }
 
 pub fn component_to_json(component: &Component) -> Result<String> {
-    match serde_json::to_string(component) {
-        Ok(res) => Ok(res),
-        Err(error) => bail!(
-            "Error occured while serializing Component to json: {}",
-            error
-        ),
-    }
+    info!(
+        serde_json::to_string(component),
+        "Error occured while serializing Component {} to json",
+        component.get_name()
+    )
 }

--- a/src/DataReader/json_writer.rs
+++ b/src/DataReader/json_writer.rs
@@ -1,6 +1,6 @@
+use crate::bail;
 use crate::ModelObjects::component::Component;
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 use std::fs::File;
 
 pub fn component_to_json_file(project_path: &str, component: &Component) {
@@ -15,7 +15,7 @@ pub fn component_to_json_file(project_path: &str, component: &Component) {
     serde_json::to_writer_pretty(&file, component).expect("Failed to serialize component");
 }
 
-pub fn component_to_json(component: &Component) -> Result<String, Box<dyn Error>> {
+pub fn component_to_json(component: &Component) -> Result<String> {
     match serde_json::to_string(component) {
         Ok(res) => Ok(res),
         Err(error) => bail!(

--- a/src/DataReader/json_writer.rs
+++ b/src/DataReader/json_writer.rs
@@ -1,4 +1,4 @@
-use crate::info;
+use crate::into_info;
 use crate::ModelObjects::component::Component;
 use anyhow::Result;
 use std::fs::File;
@@ -16,7 +16,7 @@ pub fn component_to_json_file(project_path: &str, component: &Component) {
 }
 
 pub fn component_to_json(component: &Component) -> Result<String> {
-    info!(
+    into_info!(
         serde_json::to_string(component),
         "Error occured while serializing Component {} to json",
         component.get_name()

--- a/src/DataReader/json_writer.rs
+++ b/src/DataReader/json_writer.rs
@@ -1,4 +1,4 @@
-use crate::into_info;
+use crate::into_context;
 use crate::ModelObjects::component::Component;
 use anyhow::Result;
 use std::fs::File;
@@ -16,7 +16,7 @@ pub fn component_to_json_file(project_path: &str, component: &Component) {
 }
 
 pub fn component_to_json(component: &Component) -> Result<String> {
-    into_info!(
+    into_context!(
         serde_json::to_string(component),
         "Error occured while serializing Component {} to json",
         component.get_name()

--- a/src/DataReader/json_writer.rs
+++ b/src/DataReader/json_writer.rs
@@ -1,4 +1,4 @@
-use crate::into_context;
+use crate::context;
 use crate::ModelObjects::component::Component;
 use anyhow::Result;
 use std::fs::File;
@@ -16,7 +16,7 @@ pub fn component_to_json_file(project_path: &str, component: &Component) {
 }
 
 pub fn component_to_json(component: &Component) -> Result<String> {
-    into_context!(
+    context!(
         serde_json::to_string(component),
         "Error occured while serializing Component {} to json",
         component.get_name()

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -1,7 +1,7 @@
 extern crate pest;
-use crate::{bail, open};
 use crate::DataReader::serialization::encode_boolexpr;
 use crate::ModelObjects::representations::BoolExpression;
+use crate::{bail, open};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -267,5 +267,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next(), "Expected pair but got None instead")
+    open!(iterator.next())
 }

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -1,13 +1,13 @@
 extern crate pest;
+use crate::bail;
 use crate::DataReader::serialization::encode_boolexpr;
 use crate::ModelObjects::representations::BoolExpression;
+use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
 use pest::Parser;
 use serde::{Deserialize, Serialize};
-use simple_error::bail;
 use std::collections::HashMap;
-use std::error::Error;
 
 ///This file handles parsing the edges based on the abstract syntax described in the .pest files in the grammar folder
 ///For clarification see documentation on pest crate
@@ -50,7 +50,7 @@ impl Update {
         &mut self,
         from_vars: &HashMap<String, u32>,
         to_vars: &HashMap<String, u32>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<()> {
         if let Some(index) = from_vars.get(&self.variable) {
             if let Some(new_name) =
                 to_vars
@@ -66,7 +66,7 @@ impl Update {
     }
 }
 
-pub fn parse(edge_attribute_str: &str) -> Result<EdgeAttribute, Box<dyn Error>> {
+pub fn parse(edge_attribute_str: &str) -> Result<EdgeAttribute> {
     let mut pairs = EdgeParser::parse(Rule::edgeAttribute, edge_attribute_str)?;
     let pair = try_next(&mut pairs)?;
     match pair.as_rule() {
@@ -77,9 +77,7 @@ pub fn parse(edge_attribute_str: &str) -> Result<EdgeAttribute, Box<dyn Error>> 
     }
 }
 
-pub fn build_edgeAttribute_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<EdgeAttribute, Box<dyn Error>> {
+pub fn build_edgeAttribute_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<EdgeAttribute> {
     let pair_rule = try_next(&mut pair.into_inner())?;
     match pair_rule.as_rule() {
         Rule::update => build_update_from_pair(pair_rule),
@@ -90,9 +88,7 @@ pub fn build_edgeAttribute_from_pair(
     }
 }
 
-fn build_guard_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<EdgeAttribute, Box<dyn Error>> {
+fn build_guard_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<EdgeAttribute> {
     match pair.as_rule() {
         Rule::guard => {
             let pair_span = pair.as_span();
@@ -112,9 +108,7 @@ fn build_guard_from_pair(
     }
 }
 
-fn build_update_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<EdgeAttribute, Box<dyn Error>> {
+fn build_update_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<EdgeAttribute> {
     match pair.as_rule() {
         Rule::update => {
             let mut updates: Vec<Update> = vec![];
@@ -134,9 +128,7 @@ fn build_update_from_pair(
     }
 }
 
-fn build_assignments_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<Vec<Update>, Box<dyn Error>> {
+fn build_assignments_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Vec<Update>> {
     let mut updates: Vec<Update> = vec![];
     match pair.as_rule() {
         Rule::assignments => {
@@ -166,7 +158,7 @@ fn build_assignments_from_pair(
     Ok(updates)
 }
 
-fn build_assignment_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Update, Box<dyn Error>> {
+fn build_assignment_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Update> {
     let mut inner_pairs = pair.into_inner();
     let variable = try_next(&mut inner_pairs)?.as_str();
     let expression_pair = try_next(&mut inner_pairs)?;
@@ -180,9 +172,7 @@ fn build_assignment_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Updat
     Ok(update)
 }
 
-fn build_expression_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_expression_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     match pair.as_rule() {
         Rule::term => build_term_from_pair(pair),
         Rule::parenthesizedExp => {
@@ -200,9 +190,7 @@ fn build_expression_from_pair(
     }
 }
 
-fn build_term_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_term_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let inner_pair = try_next(&mut pair.into_inner())?;
     match inner_pair.as_rule() {
         Rule::atom => {
@@ -221,9 +209,7 @@ fn build_term_from_pair(
     }
 }
 
-fn build_and_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_and_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -238,7 +224,7 @@ fn build_and_from_pair(
     }
 }
 
-fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -253,9 +239,7 @@ fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpressio
     }
 }
 
-fn build_compareExpr_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -282,7 +266,7 @@ fn build_compareExpr_from_pair(
     }
 }
 
-fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>, Box<dyn Error>> {
+fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
     if let Some(pair) = iterator.next() {
         Ok(pair)
     } else {

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -1,7 +1,7 @@
 extern crate pest;
 use crate::DataReader::serialization::encode_boolexpr;
 use crate::ModelObjects::representations::BoolExpression;
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -267,5 +267,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next())
+    to_result!(iterator.next())
 }

--- a/src/DataReader/parse_edge.rs
+++ b/src/DataReader/parse_edge.rs
@@ -1,5 +1,5 @@
 extern crate pest;
-use crate::bail;
+use crate::{bail, open};
 use crate::DataReader::serialization::encode_boolexpr;
 use crate::ModelObjects::representations::BoolExpression;
 use anyhow::Result;
@@ -267,9 +267,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    if let Some(pair) = iterator.next() {
-        Ok(pair)
-    } else {
-        bail!("Expected pair but got None instead")
-    }
+    open!(iterator.next(), "Expected pair but got None instead")
 }

--- a/src/DataReader/parse_invariant.rs
+++ b/src/DataReader/parse_invariant.rs
@@ -1,6 +1,6 @@
 extern crate pest;
 use crate::ModelObjects::representations::BoolExpression;
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -136,5 +136,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next())
+    to_result!(iterator.next())
 }

--- a/src/DataReader/parse_invariant.rs
+++ b/src/DataReader/parse_invariant.rs
@@ -1,6 +1,6 @@
 extern crate pest;
-use crate::bail;
 use crate::ModelObjects::representations::BoolExpression;
+use crate::{bail, open};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -136,9 +136,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    if let Some(pair) = iterator.next() {
-        Ok(pair)
-    } else {
-        bail!("Expected pair but got None instead")
-    }
+    open!(iterator.next(), "Expected pair but got None instead")
 }

--- a/src/DataReader/parse_invariant.rs
+++ b/src/DataReader/parse_invariant.rs
@@ -136,5 +136,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Bool
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next(), "Expected pair but got None instead")
+    open!(iterator.next())
 }

--- a/src/DataReader/parse_invariant.rs
+++ b/src/DataReader/parse_invariant.rs
@@ -1,10 +1,10 @@
 extern crate pest;
+use crate::bail;
 use crate::ModelObjects::representations::BoolExpression;
+use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
 use pest::Parser;
-use simple_error::bail;
-use std::error::Error;
 
 /// This file handles parsing the invariants based on the abstract syntax described in the .pest files in the grammar folder
 /// For clarification see documentation on pest crate
@@ -12,7 +12,7 @@ use std::error::Error;
 #[grammar = "DataReader/grammars/invariant_grammar.pest"]
 pub struct InvariantParser;
 
-pub fn parse(edge_attribute_str: &str) -> Result<BoolExpression, Box<dyn Error>> {
+pub fn parse(edge_attribute_str: &str) -> Result<BoolExpression> {
     let mut pairs = InvariantParser::parse(Rule::invariant, edge_attribute_str)?;
     let pair = try_next(&mut pairs)?;
     match pair.as_rule() {
@@ -23,9 +23,7 @@ pub fn parse(edge_attribute_str: &str) -> Result<BoolExpression, Box<dyn Error>>
     }
 }
 
-pub fn build_invariant_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+pub fn build_invariant_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let pair = try_next(&mut pair.into_inner())?;
     match pair.as_rule() {
         Rule::andExpr => {
@@ -45,9 +43,7 @@ pub fn build_invariant_from_pair(
     }
 }
 
-fn build_expression_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_expression_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     match pair.as_rule() {
         Rule::term => build_term_from_pair(pair),
         Rule::parenthesizedExp => {
@@ -64,9 +60,7 @@ fn build_expression_from_pair(
     }
 }
 
-fn build_term_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_term_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let inner_pair = try_next(&mut pair.into_inner())?;
     match inner_pair.as_rule() {
         Rule::atom => {
@@ -85,9 +79,7 @@ fn build_term_from_pair(
     }
 }
 
-fn build_and_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_and_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -102,7 +94,7 @@ fn build_and_from_pair(
     }
 }
 
-fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -117,9 +109,7 @@ fn build_or_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpressio
     }
 }
 
-fn build_compareExpr_from_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<BoolExpression, Box<dyn Error>> {
+fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<BoolExpression> {
     let mut inner_pair = pair.into_inner();
     let left_side_pair = try_next(&mut inner_pair)?;
 
@@ -145,7 +135,7 @@ fn build_compareExpr_from_pair(
     }
 }
 
-fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>, Box<dyn Error>> {
+fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
     if let Some(pair) = iterator.next() {
         Ok(pair)
     } else {

--- a/src/DataReader/parse_queries.rs
+++ b/src/DataReader/parse_queries.rs
@@ -1,7 +1,7 @@
 extern crate pest;
-use crate::bail;
 use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::representations::QueryExpression;
+use crate::{bail, open};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -351,9 +351,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Quer
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    if let Some(pair) = iterator.next() {
-        Ok(pair)
-    } else {
-        bail!("Expected pair but got None instead")
-    }
+    open!(iterator.next(), "Expected pair but got None instead")
 }

--- a/src/DataReader/parse_queries.rs
+++ b/src/DataReader/parse_queries.rs
@@ -351,5 +351,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Quer
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next(), "Expected pair but got None instead")
+    open!(iterator.next())
 }

--- a/src/DataReader/parse_queries.rs
+++ b/src/DataReader/parse_queries.rs
@@ -1,7 +1,7 @@
 extern crate pest;
 use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::representations::QueryExpression;
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -351,5 +351,5 @@ fn build_compareExpr_from_pair(pair: pest::iterators::Pair<Rule>) -> Result<Quer
 }
 
 fn try_next<'i>(iterator: &mut Pairs<'i, Rule>) -> Result<Pair<'i, Rule>> {
-    open!(iterator.next())
+    to_result!(iterator.next())
 }

--- a/src/DataReader/xml_parser.rs
+++ b/src/DataReader/xml_parser.rs
@@ -3,7 +3,7 @@ use crate::DataReader::{parse_edge, parse_invariant};
 use crate::ModelObjects::component::{Declarations, Edge, LocationType, SyncType};
 use crate::ModelObjects::system_declarations::{SystemDeclarations, SystemSpecification};
 use crate::ModelObjects::{component, queries, representations, system_declarations};
-use crate::{bail, info, open};
+use crate::{bail, context, open};
 use anyhow::Result;
 use elementtree::{Element, FindChildren};
 use std::collections::HashMap;
@@ -135,7 +135,7 @@ fn collect_edges(xml_edges: FindChildren) -> Result<Vec<Edge>> {
                     sync = label.text().to_string();
                 }
                 "assignment" => {
-                    if let parse_edge::EdgeAttribute::Updates(update_vec) = info!(
+                    if let parse_edge::EdgeAttribute::Updates(update_vec) = context!(
                         parse_edge::parse(label.text()),
                         "Could not parse edge {}",
                         label.text()
@@ -301,17 +301,9 @@ fn decode_sync_type(global_decl: &str) -> Result<SystemSpecification> {
 }
 
 fn find_element<'a>(elem: &'a Element, search_str: &'a str) -> Result<&'a Element> {
-    open!(
-        elem.find(search_str),
-        "Expected element {} but got None instead while parsing XML",
-        search_str
-    )
+    open!(elem.find(search_str))
 }
 
 fn get_attribute<'a>(elem: &'a Element, attribute_name: &'a str) -> Result<&'a str> {
-    open!(
-        elem.get_attr(attribute_name),
-        "Expected attribute {} but got None while parsing XML",
-        attribute_name
-    )
+    open!(elem.get_attr(attribute_name))
 }

--- a/src/DataReader/xml_parser.rs
+++ b/src/DataReader/xml_parser.rs
@@ -3,7 +3,7 @@ use crate::DataReader::{parse_edge, parse_invariant};
 use crate::ModelObjects::component::{Declarations, Edge, LocationType, SyncType};
 use crate::ModelObjects::system_declarations::{SystemDeclarations, SystemSpecification};
 use crate::ModelObjects::{component, queries, representations, system_declarations};
-use crate::{bail, context, open};
+use crate::{bail, context, to_result};
 use anyhow::Result;
 use elementtree::{Element, FindChildren};
 use std::collections::HashMap;
@@ -301,9 +301,9 @@ fn decode_sync_type(global_decl: &str) -> Result<SystemSpecification> {
 }
 
 fn find_element<'a>(elem: &'a Element, search_str: &'a str) -> Result<&'a Element> {
-    open!(elem.find(search_str))
+    to_result!(elem.find(search_str))
 }
 
 fn get_attribute<'a>(elem: &'a Element, attribute_name: &'a str) -> Result<&'a str> {
-    open!(elem.get_attr(attribute_name))
+    to_result!(elem.get_attr(attribute_name))
 }

--- a/src/EdgeEval/constraint_applyer.rs
+++ b/src/EdgeEval/constraint_applyer.rs
@@ -1,14 +1,14 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component;
 use crate::ModelObjects::representations::BoolExpression;
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 
 pub fn apply_constraint(
     constraint: &Option<BoolExpression>,
     decls: &component::Declarations,
     zone: &mut Zone,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if let Some(guards) = constraint {
         apply_constraints_to_state(guards, decls, zone)
     } else {
@@ -20,7 +20,7 @@ pub fn apply_constraints_to_state(
     guard: &BoolExpression,
     decls: &component::Declarations,
     zone: &mut Zone,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if let BoolExpression::Bool(val) =
         apply_constraints_to_state_helper(guard, decls, zone, true)?.0
     {
@@ -34,7 +34,7 @@ pub fn apply_constraints_to_state_declarations(
     guard: &BoolExpression,
     decls: &component::Declarations,
     zone: &mut Zone,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if let BoolExpression::Bool(val) =
         apply_constraints_to_state_helper(guard, decls, zone, true)?.0
     {
@@ -49,7 +49,7 @@ pub fn apply_constraints_to_state_helper(
     decls: &component::Declarations,
     zone: &mut Zone,
     should_apply: bool,
-) -> Result<(BoolExpression, bool), Box<dyn Error>> {
+) -> Result<(BoolExpression, bool)> {
     match guard {
         BoolExpression::AndOp(left, right) => {
             let (left, _contains_clock_left) =
@@ -330,7 +330,7 @@ pub fn apply_constraints_to_state2(
     guard: &BoolExpression,
     state: &mut component::State,
     comp_index: usize,
-) -> Result<BoolExpression, Box<dyn Error>> {
+) -> Result<BoolExpression> {
     match guard {
         BoolExpression::AndOp(left, right) => {
             let left = apply_constraints_to_state2(&**left, state, comp_index)?;

--- a/src/EdgeEval/updater.rs
+++ b/src/EdgeEval/updater.rs
@@ -1,16 +1,16 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::DataReader::parse_edge;
 use crate::ModelObjects::component;
 use crate::ModelObjects::representations::BoolExpression;
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 
 /// Used to handle update expressions on edges
 pub fn updater(
     updates: &[parse_edge::Update],
     decl: &component::Declarations,
     zone: &mut Zone,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     for update in updates {
         match update.get_expression() {
             BoolExpression::Int(val) => {
@@ -31,7 +31,7 @@ pub fn state_updater(
     updates: &[parse_edge::Update],
     state: &mut component::State,
     comp_index: usize,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     for update in updates {
         match update.get_expression() {
             BoolExpression::Int(val) => {

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -27,7 +27,7 @@ macro_rules! error {
 
 /// Try to unwrap an option and on fail return an error with file and line number information
 #[macro_export]
-macro_rules! open {
+macro_rules! to_result {
     ($option:expr) => {
         $option.ok_or($crate::error!(
             "Optional was expected to be Some but was None"

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 
 #[doc(hidden)]
-pub fn _add_info_to_result<T>(res: Result<T>, info: String) -> Result<T> {
+pub fn _add_info_to_result<T, E, R: Context<T, E>>(res: R, info: String) -> Result<T> {
     res.with_context(|| info)
 }
 
-/// Add file and line number information + optional context to an anyhow::Result
+/// Add file and line number information + optional context to an Option<T> or an anyhow::Result<T, E>
 #[macro_export]
 macro_rules! info {
     ($result:expr) => { info!($result, "Caused an error") };
@@ -25,11 +25,14 @@ macro_rules! into_info {
     ($result:expr, $($args:expr ),*) => { $crate::info!($result.map_err(anyhow::Error::msg), $($args ),*) };
 }
 
-/// Convert an option to a result with file and line number information + optional context
+/// Try to unwrap an option and on fail return an error with file and line number information
 #[macro_export]
 macro_rules! open {
-    ($option:expr) => { open!($option, "Failed to open Option") };
-    ($option:expr, $($args:expr ),*) => {$option.ok_or($crate::error!( $( $args ),*))}
+    ($option:expr) => {
+        $option.ok_or($crate::error!(
+            "Optional was expected to be Some but was None"
+        ))
+    };
 }
 
 /// Bail with a result with file and line number information + optional context

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -7,8 +7,8 @@ pub fn _add_info_to_result<T, E, R: Context<T, E>>(res: R, info: String) -> Resu
 
 /// Add file and line number information + optional context to an Option<T> or an anyhow::Result<T, E>
 #[macro_export]
-macro_rules! info {
-    ($result:expr) => { info!($result, "Caused an error") };
+macro_rules! context {
+    ($result:expr) => { context!($result, "Unexpected error") };
     ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result, format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* ))) };
 }
 
@@ -20,9 +20,9 @@ macro_rules! error {
 
 /// Convert any Result into an anyhow::Result and add file and line number information + optional context
 #[macro_export]
-macro_rules! into_info {
-    ($result:expr) => { $crate::info!($result.map_err(anyhow::Error::msg)) };
-    ($result:expr, $($args:expr ),*) => { $crate::info!($result.map_err(anyhow::Error::msg), $($args ),*) };
+macro_rules! into_context {
+    ($result:expr) => { $crate::context!($result.map_err(anyhow::Error::msg)) };
+    ($result:expr, $($args:expr ),*) => { $crate::context!($result.map_err(anyhow::Error::msg), $($args ),*) };
 }
 
 /// Try to unwrap an option and on fail return an error with file and line number information

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -12,7 +12,7 @@ macro_rules! location {
     };
 }
 
-/// Add file and line number information + optional context to an Option<T> or an anyhow::Result<T, E>
+/// Add file and line number information + optional context to an Option<T> or Result<T, E>
 #[macro_export]
 macro_rules! context {
     ($result:expr) => { context!($result, "Unexpected error") };
@@ -23,13 +23,6 @@ macro_rules! context {
 #[macro_export]
 macro_rules! error {
     ($($args:expr ),*) => {$crate::anyhow::Error::msg(format!("{}\n\t at {}", format!( $( $args ),* ), crate::location!()))}
-}
-
-/// Convert any Result into an anyhow::Result and add file and line number information + optional context
-#[macro_export]
-macro_rules! into_context {
-    ($result:expr) => { $crate::context!($result.map_err(anyhow::Error::msg)) };
-    ($result:expr, $($args:expr ),*) => { $crate::context!($result.map_err(anyhow::Error::msg), $($args ),*) };
 }
 
 /// Try to unwrap an option and on fail return an error with file and line number information

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -5,17 +5,24 @@ pub fn _add_info_to_result<T, E, R: Context<T, E>>(res: R, info: String) -> Resu
     res.with_context(|| info)
 }
 
+#[macro_export]
+macro_rules! location {
+    () => {
+        concat!(file!(), ":", line!(), ":", column!())
+    };
+}
+
 /// Add file and line number information + optional context to an Option<T> or an anyhow::Result<T, E>
 #[macro_export]
 macro_rules! context {
     ($result:expr) => { context!($result, "Unexpected error") };
-    ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result, format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* ))) };
+    ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result, format!("{}\n\t at {}", format!( $( $args ),* ), crate::location!())) };
 }
 
 /// Construct an anyhow::Error with file and line number information
 #[macro_export]
 macro_rules! error {
-    ($($args:expr ),*) => {$crate::anyhow::Error::msg(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
+    ($($args:expr ),*) => {$crate::anyhow::Error::msg(format!("{}\n\t at {}", format!( $( $args ),* ), crate::location!()))}
 }
 
 /// Convert any Result into an anyhow::Result and add file and line number information + optional context
@@ -38,5 +45,5 @@ macro_rules! open {
 /// Bail with a result with file and line number information + optional context
 #[macro_export]
 macro_rules! bail {
-    ($($args:expr ),*) => {$crate::anyhow::bail!(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
+    ($($args:expr ),*) => {$crate::anyhow::bail!(format!("{}\n\t at {}", format!( $( $args ),* ), crate::location!()))}
 }

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -5,23 +5,34 @@ pub fn _add_info_to_result<T>(res: Result<T>, info: String) -> Result<T> {
     res.with_context(|| info)
 }
 
+/// Add file and line number information + optional context to an anyhow::Result
 #[macro_export]
 macro_rules! info {
-    ($result:expr) => { info!($result, "") };
-    ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result.map_err(|err| err.into()), format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* ))) };
+    ($result:expr) => { info!($result, "Caused an error") };
+    ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result, format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* ))) };
 }
 
+/// Construct an anyhow::Error with file and line number information
 #[macro_export]
 macro_rules! error {
     ($($args:expr ),*) => {$crate::anyhow::Error::msg(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
 }
 
+/// Convert any Result into an anyhow::Result and add file and line number information + optional context
+#[macro_export]
+macro_rules! into_info {
+    ($result:expr) => { $crate::info!($result.map_err(anyhow::Error::msg)) };
+    ($result:expr, $($args:expr ),*) => { $crate::info!($result.map_err(anyhow::Error::msg), $($args ),*) };
+}
+
+/// Convert an option to a result with file and line number information + optional context
 #[macro_export]
 macro_rules! open {
     ($option:expr) => { open!($option, "Failed to open Option") };
     ($option:expr, $($args:expr ),*) => {$option.ok_or($crate::error!( $( $args ),*))}
 }
 
+/// Bail with a result with file and line number information + optional context
 #[macro_export]
 macro_rules! bail {
     ($($args:expr ),*) => {$crate::anyhow::bail!(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}

--- a/src/Macros/errors.rs
+++ b/src/Macros/errors.rs
@@ -1,0 +1,28 @@
+use anyhow::{Context, Result};
+
+#[doc(hidden)]
+pub fn _add_info_to_result<T>(res: Result<T>, info: String) -> Result<T> {
+    res.with_context(|| info)
+}
+
+#[macro_export]
+macro_rules! info {
+    ($result:expr) => { info!($result, "") };
+    ($result:expr, $($args:expr ),*) => { $crate::Macros::errors::_add_info_to_result($result.map_err(|err| err.into()), format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* ))) };
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($args:expr ),*) => {$crate::anyhow::Error::msg(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
+}
+
+#[macro_export]
+macro_rules! open {
+    ($option:expr) => { open!($option, "Failed to open Option") };
+    ($option:expr, $($args:expr ),*) => {$option.ok_or($crate::error!( $( $args ),*))}
+}
+
+#[macro_export]
+macro_rules! bail {
+    ($($args:expr ),*) => {$crate::anyhow::bail!(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
+}

--- a/src/Macros/mod.rs
+++ b/src/Macros/mod.rs
@@ -1,0 +1,1 @@
+pub mod errors;

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -94,16 +94,10 @@ impl Component {
     }
 
     pub fn get_input_edges(&self) -> Result<&Vec<Edge>> {
-        open!(
-            self.input_edges.as_ref(),
-            "attempted to get input edges before they were created"
-        )
+        open!(self.input_edges.as_ref())
     }
     pub fn get_output_edges(&self) -> Result<&Vec<Edge>> {
-        open!(
-            self.output_edges.as_ref(),
-            "attempted to get output edges before they were created"
-        )
+        open!(self.output_edges.as_ref())
     }
 
     pub fn get_initial_location(&self) -> Option<&Location> {
@@ -471,7 +465,7 @@ impl Component {
         add_state_to_wl(&mut waiting_list, state);
 
         while !waiting_list.is_empty() {
-            let state = open!(waiting_list.pop(), "unable to pop from waiting list")?;
+            let state = open!(waiting_list.pop())?;
             let mut full_state = state;
             let mut edges: Vec<&Edge> = vec![];
             for input_action in self.get_input_actions()? {
@@ -1109,11 +1103,7 @@ impl Declarations {
     }
 
     pub fn get_clock_index_by_name(&self, name: &str) -> Result<u32> {
-        open!(
-            self.get_clocks().get(name).copied(),
-            "Failed to find clock index of clock {}",
-            name
-        )
+        open!(self.get_clocks().get(name).copied())
     }
 }
 

--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -13,7 +13,7 @@ use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::representations;
 use crate::ModelObjects::representations::BoolExpression;
 use crate::TransitionSystems::LocationTuple;
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -94,10 +94,10 @@ impl Component {
     }
 
     pub fn get_input_edges(&self) -> Result<&Vec<Edge>> {
-        open!(self.input_edges.as_ref())
+        to_result!(self.input_edges.as_ref())
     }
     pub fn get_output_edges(&self) -> Result<&Vec<Edge>> {
-        open!(self.output_edges.as_ref())
+        to_result!(self.output_edges.as_ref())
     }
 
     pub fn get_initial_location(&self) -> Option<&Location> {
@@ -465,7 +465,7 @@ impl Component {
         add_state_to_wl(&mut waiting_list, state);
 
         while !waiting_list.is_empty() {
-            let state = open!(waiting_list.pop())?;
+            let state = to_result!(waiting_list.pop())?;
             let mut full_state = state;
             let mut edges: Vec<&Edge> = vec![];
             for input_action in self.get_input_actions()? {
@@ -1103,7 +1103,7 @@ impl Declarations {
     }
 
     pub fn get_clock_index_by_name(&self, name: &str) -> Result<u32> {
-        open!(self.get_clocks().get(name).copied())
+        to_result!(self.get_clocks().get(name).copied())
     }
 }
 

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -61,7 +61,7 @@ impl BoolExpression {
             BoolExpression::Parentheses(body) => {
                 Ok(BoolExpression::Parentheses(Box::new(body.swap_clock_names(from_vars, to_vars)?)))
             }
-            BoolExpression::Clock(_) => bail!("Did not expect clock index in boolexpression, cannot swap clock names in misformed BoolExpression"),
+            BoolExpression::Clock(_) => bail!("Did not expect clock index in boolexpression {:?}, cannot swap clock names in misformed BoolExpression", self),
             BoolExpression::VarName(name) => {
                 if let Some(index) = from_vars.get(name){
                     if let Some(new_name) = to_vars.iter()

--- a/src/ModelObjects/representations.rs
+++ b/src/ModelObjects/representations.rs
@@ -1,7 +1,7 @@
+use crate::bail;
+use anyhow::Result;
 use serde::Deserialize;
-use simple_error::bail;
 use std::collections::HashMap;
-use std::error::Error;
 
 /// This file contains the nested enums used to represent systems on each side of refinement as well as all guards, updates etc
 /// note that the enum contains a box (pointer) to an object as they can only hold pointers to data on the heap
@@ -27,7 +27,7 @@ impl BoolExpression {
         &self,
         from_vars: &HashMap<String, u32>,
         to_vars: &HashMap<String, u32>,
-    ) -> Result<BoolExpression, Box<dyn Error>> {
+    ) -> Result<BoolExpression> {
         match self {
             BoolExpression::AndOp(left, right) => Ok(BoolExpression::AndOp(
                 Box::new(left.swap_clock_names(from_vars, to_vars)?),

--- a/src/ModelObjects/system_declarations.rs
+++ b/src/ModelObjects/system_declarations.rs
@@ -1,8 +1,8 @@
 use crate::ModelObjects::component::Component;
+use anyhow::Result;
 use serde::de::Error as serde_error;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
-use std::error::Error;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SystemDeclarations {
@@ -23,7 +23,7 @@ impl SystemDeclarations {
         self.get_declarations().get_input_actions().get(comp_name)
     }
 
-    pub fn add_component(&mut self, comp: &Component) -> Result<(), Box<dyn Error>> {
+    pub fn add_component(&mut self, comp: &Component) -> Result<()> {
         self.declarations.input_actions.insert(
             comp.get_name().clone(),
             comp.get_input_actions()?

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -1,8 +1,8 @@
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackend;
 
 use crate::ProtobufServer::services::{ComponentsUpdateRequest, Query, QueryResponse};
+use anyhow::Result;
 use std::cell::RefCell;
-use std::error::Error;
 use std::sync::{Mutex, MutexGuard};
 use tonic::{Request, Response, Status};
 
@@ -44,7 +44,7 @@ pub trait ToGrpcResult<T>: Sized {
     fn as_grpc_result(self) -> Result<T, Status>;
 }
 
-impl<T> ToGrpcResult<T> for Result<T, Box<dyn Error>> {
+impl<T> ToGrpcResult<T> for Result<T> {
     fn as_grpc_result(self) -> Result<T, Status> {
         match self {
             Ok(value) => Ok(value),

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -48,7 +48,7 @@ impl<T> ToGrpcResult<T> for Result<T> {
     fn as_grpc_result(self) -> Result<T, Status> {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Status::internal(format!("{}", error))),
+            Err(error) => Err(Status::internal(error.to_string())),
         }
     }
 }

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -1,6 +1,6 @@
+use crate::context;
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackendServer;
 use crate::ProtobufServer::ConcreteEcdarBackend;
-use crate::{context, into_context};
 use anyhow::Result;
 
 use core::time::Duration;
@@ -25,13 +25,13 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<()> {
 async fn start_grpc_server(ip_endpoint: &str) -> Result<()> {
     println!("Starting grpc server on '{}'", ip_endpoint.trim());
 
-    let addr = into_context!(
+    let addr = context!(
         ip_endpoint.trim().parse(),
         "Failed to parse ip address \"{}\"",
         ip_endpoint
     )?;
 
-    into_context!(
+    context!(
         Server::builder()
             .http2_keepalive_interval(Some(Duration::from_secs(120)))
             .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -1,10 +1,13 @@
+use crate::info;
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackendServer;
 use crate::ProtobufServer::ConcreteEcdarBackend;
+use anyhow::Result;
+
 use core::time::Duration;
 use tokio::runtime;
 use tonic::transport::Server;
 
-pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<()> {
     //For information on switching to a multithreaded server see:
     //https://docs.rs/tokio/1.12.0/tokio/runtime/index.html#multi-thread-scheduler
     let single_threaded_runtime = runtime::Builder::new_current_thread()
@@ -12,12 +15,15 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<(), Box<dyn std
         .enable_io()
         .build()?;
 
-    single_threaded_runtime.block_on(async { start_grpc_server(ip_endpoint).await })
+    info!(
+        single_threaded_runtime.block_on(async { start_grpc_server(ip_endpoint).await }),
+        "Failed to start grpc server on address \"{}\"", ip_endpoint
+    );
+    Ok(())
 }
 
-async fn start_grpc_server(ip_endpoint: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn start_grpc_server(ip_endpoint: &str) -> Result<()> {
     println!("Starting grpc server on '{}'", ip_endpoint.trim());
-
     Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(120)))
         .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -1,6 +1,6 @@
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackendServer;
 use crate::ProtobufServer::ConcreteEcdarBackend;
-use crate::{info, into_info};
+use crate::{context, into_context};
 use anyhow::Result;
 
 use core::time::Duration;
@@ -15,22 +15,23 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<()> {
         .enable_io()
         .build()?;
 
-    info!(
+    context!(
         single_threaded_runtime.block_on(async { start_grpc_server(ip_endpoint).await }),
-        "Failed to start grpc server on address \"{}\"", ip_endpoint
+        "Failed to start grpc server on address \"{}\"",
+        ip_endpoint
     )
 }
 
 async fn start_grpc_server(ip_endpoint: &str) -> Result<()> {
     println!("Starting grpc server on '{}'", ip_endpoint.trim());
 
-    let addr = into_info!(
+    let addr = into_context!(
         ip_endpoint.trim().parse(),
         "Failed to parse ip address \"{}\"",
         ip_endpoint
     )?;
 
-    into_info!(
+    into_context!(
         Server::builder()
             .http2_keepalive_interval(Some(Duration::from_secs(120)))
             .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -18,17 +18,19 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<()> {
     info!(
         single_threaded_runtime.block_on(async { start_grpc_server(ip_endpoint).await }),
         "Failed to start grpc server on address \"{}\"", ip_endpoint
-    );
-    Ok(())
+    )
 }
 
 async fn start_grpc_server(ip_endpoint: &str) -> Result<()> {
     println!("Starting grpc server on '{}'", ip_endpoint.trim());
-    Server::builder()
-        .http2_keepalive_interval(Some(Duration::from_secs(120)))
-        .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))
-        .serve(ip_endpoint.trim().parse()?)
-        .await?;
+    let addr = ip_endpoint.trim().parse()?;
+    info!(
+        Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_secs(120)))
+            .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))
+            .serve(addr)
+            .await
+    )?;
 
     Ok(())
 }

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -1,6 +1,6 @@
-use crate::info;
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackendServer;
 use crate::ProtobufServer::ConcreteEcdarBackend;
+use crate::{info, into_info};
 use anyhow::Result;
 
 use core::time::Duration;
@@ -23,8 +23,14 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<()> {
 
 async fn start_grpc_server(ip_endpoint: &str) -> Result<()> {
     println!("Starting grpc server on '{}'", ip_endpoint.trim());
-    let addr = ip_endpoint.trim().parse()?;
-    info!(
+
+    let addr = into_info!(
+        ip_endpoint.trim().parse(),
+        "Failed to parse ip address \"{}\"",
+        ip_endpoint
+    )?;
+
+    into_info!(
         Server::builder()
             .http2_keepalive_interval(Some(Duration::from_secs(120)))
             .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -3,7 +3,7 @@ use crate::ModelObjects::component::Component;
 use crate::System::save_component::combine_components;
 use crate::System::{extra_actions, refine};
 use crate::TransitionSystems::TransitionSystemPtr;
-use std::error::Error;
+use anyhow::Result;
 
 pub enum QueryResult {
     Refinement(bool),
@@ -43,7 +43,7 @@ fn not_satisfied(query_str: &str) {
 }
 
 pub trait ExecutableQuery {
-    fn execute(self: Box<Self>) -> Result<QueryResult, Box<dyn Error>>;
+    fn execute(self: Box<Self>) -> Result<QueryResult>;
 }
 
 pub struct RefinementExecutor {
@@ -52,7 +52,7 @@ pub struct RefinementExecutor {
 }
 
 impl ExecutableQuery for RefinementExecutor {
-    fn execute(self: Box<Self>) -> Result<QueryResult, Box<dyn Error>> {
+    fn execute(self: Box<Self>) -> Result<QueryResult> {
         let (sys1, sys2) = extra_actions::add_extra_inputs_outputs(self.sys1, self.sys2)?;
 
         match refine::check_refinement(sys1, sys2)? {
@@ -72,7 +72,7 @@ pub struct GetComponentExecutor<'a> {
 }
 
 impl<'a> ExecutableQuery for GetComponentExecutor<'a> {
-    fn execute(self: Box<Self>) -> Result<QueryResult, Box<dyn Error>> {
+    fn execute(self: Box<Self>) -> Result<QueryResult> {
         let mut comp = combine_components(&self.system)?;
         comp.name = self.comp_name;
 
@@ -89,7 +89,7 @@ pub struct ConsistencyExecutor {
 }
 
 impl<'a> ExecutableQuery for ConsistencyExecutor {
-    fn execute(self: Box<Self>) -> Result<QueryResult, Box<dyn Error>> {
+    fn execute(self: Box<Self>) -> Result<QueryResult> {
         let dim = self.system.get_num_clocks() + 1;
         Ok(QueryResult::Consistency(self.system.precheck_sys_rep(dim)?))
     }
@@ -100,7 +100,7 @@ pub struct DeterminismExecutor {
 }
 
 impl<'a> ExecutableQuery for DeterminismExecutor {
-    fn execute(self: Box<Self>) -> Result<QueryResult, Box<dyn Error>> {
+    fn execute(self: Box<Self>) -> Result<QueryResult> {
         let dim = self.system.get_num_clocks() + 1;
         let is_deterministic = self.system.is_deterministic(dim)?;
 

--- a/src/System/extra_actions.rs
+++ b/src/System/extra_actions.rs
@@ -1,11 +1,11 @@
 use crate::ModelObjects::component::get_dummy_component;
 use crate::TransitionSystems::{Composition, TransitionSystemPtr};
-use std::error::Error;
+use anyhow::Result;
 
 pub fn add_extra_inputs_outputs(
     sys1: TransitionSystemPtr,
     sys2: TransitionSystemPtr,
-) -> Result<(TransitionSystemPtr, TransitionSystemPtr), Box<dyn Error>> {
+) -> Result<(TransitionSystemPtr, TransitionSystemPtr)> {
     let inputs1 = get_extra(&sys1, &sys2, true)?;
     let outputs2 = get_extra(&sys2, &sys1, false)?;
 
@@ -26,7 +26,7 @@ fn get_extra(
     sys1: &TransitionSystemPtr,
     sys2: &TransitionSystemPtr,
     is_input: bool,
-) -> Result<Vec<String>, Box<dyn Error>> {
+) -> Result<Vec<String>> {
     let actions1 = if is_input {
         sys1.get_input_actions()?
     } else {

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -1,3 +1,4 @@
+use crate::bail;
 use crate::DataReader::component_loader::ComponentLoader;
 use crate::ModelObjects::queries::Query;
 use crate::ModelObjects::representations::QueryExpression;
@@ -9,15 +10,14 @@ use crate::System::pruning;
 use crate::TransitionSystems::{
     Composition, Conjunction, Quotient, TransitionSystem, TransitionSystemPtr,
 };
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 
 /// This function fetches the appropriate components based on the structure of the query and makes the enum structure match the query
 /// this function also handles setting up the correct indices for clocks based on the amount of components in each system representation
 pub fn create_executable_query<'a>(
     full_query: &Query,
     component_loader: &'a mut (dyn ComponentLoader + 'static),
-) -> Result<Box<dyn ExecutableQuery + 'a>, Box<dyn Error>> {
+) -> Result<Box<dyn ExecutableQuery + 'a>> {
     let mut clock_index: u32 = 0;
 
     let query = full_query.get_query();
@@ -81,7 +81,7 @@ pub fn extract_side(
     side: &QueryExpression,
     component_loader: &mut dyn ComponentLoader,
     clock_index: &mut u32,
-) -> Result<TransitionSystemPtr, Box<dyn Error>> {
+) -> Result<TransitionSystemPtr> {
     match side {
         QueryExpression::Parentheses(expression) => {
             extract_side(expression, component_loader, clock_index)

--- a/src/System/input_enabler.rs
+++ b/src/System/input_enabler.rs
@@ -4,13 +4,10 @@ use crate::ModelObjects::component;
 use crate::ModelObjects::component::DeclarationProvider;
 use crate::ModelObjects::representations;
 use crate::TransitionSystems::TransitionSystem;
+use anyhow::Result;
 use std::collections::HashMap;
-use std::error::Error;
 
-pub fn make_input_enabled(
-    component: &mut component::Component,
-    inputs: &[String],
-) -> Result<(), Box<dyn Error>> {
+pub fn make_input_enabled(component: &mut component::Component, inputs: &[String]) -> Result<()> {
     let dimension = (component as &dyn TransitionSystem).get_max_clock_index() + 1;
     let mut new_edges: Vec<component::Edge> = vec![];
 

--- a/src/System/local_consistency.rs
+++ b/src/System/local_consistency.rs
@@ -1,14 +1,11 @@
+use crate::bail;
 use crate::ModelObjects::component::State;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::TransitionSystems::TransitionSystem;
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 
 //Local consistency check WITH pruning
-pub fn is_least_consistent(
-    system: &dyn TransitionSystem,
-    dimensions: u32,
-) -> Result<bool, Box<dyn Error>> {
+pub fn is_least_consistent(system: &dyn TransitionSystem, dimensions: u32) -> Result<bool> {
     if system.get_initial_location() == None {
         return Ok(false); //TODO: figure out whether we want empty TS to be consistent
     }
@@ -21,10 +18,7 @@ pub fn is_least_consistent(
 }
 
 //Local consistency check WITHOUT pruning
-pub fn is_fully_consistent(
-    system: &dyn TransitionSystem,
-    dimensions: u32,
-) -> Result<bool, Box<dyn Error>> {
+pub fn is_fully_consistent(system: &dyn TransitionSystem, dimensions: u32) -> Result<bool> {
     if system.get_initial_location() == None {
         return Ok(false);
     }
@@ -41,7 +35,7 @@ pub fn consistency_least_helper<'b>(
     passed_list: &mut Vec<State<'b>>,
     system: &'b dyn TransitionSystem,
     max_bounds: &MaxBounds,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if passed_list.contains(&state) {
         return Ok(true);
     }
@@ -85,7 +79,7 @@ fn consistency_fully_helper<'b>(
     passed_list: &mut Vec<State<'b>>,
     system: &'b dyn TransitionSystem,
     max_bounds: &MaxBounds,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if passed_list.contains(&state) {
         return Ok(true);
     }

--- a/src/System/pruning.rs
+++ b/src/System/pruning.rs
@@ -1,4 +1,4 @@
-use crate::bail;
+use crate::open;
 use crate::DBMLib::dbm::{Federation, Zone};
 use crate::EdgeEval::constraint_applyer::apply_constraint;
 use crate::ModelObjects::component::{Component, Declarations, Edge, Location, SyncType};
@@ -127,13 +127,11 @@ fn is_inconsistent(
         Federation::new(vec![], dimensions)
     };
 
-    let cons_fed = match consistent_parts.get(location.get_id()) {
-        Some(fed) => fed,
-        None => bail!(
-            "Couldnt find the location {} in the consistent_parts map",
-            location.get_id()
-        ),
-    };
+    let cons_fed = open!(
+        consistent_parts.get(location.get_id()),
+        "Couldn't find the location {} in the consistent_parts map",
+        location.get_id()
+    )?;
 
     //Returns whether the consistent part is strictly less than the zone induced by the invariant
     Ok(cons_fed.is_subset_eq(&inv_fed) && !inv_fed.is_subset_eq(&cons_fed))
@@ -149,13 +147,11 @@ fn prune_to_consistent_part(
     if !is_inconsistent(location, consistent_parts, decls, dimensions)? {
         return Ok(false);
     }
-    let cons_fed = match consistent_parts.get(location.get_id()) {
-        Some(fed) => fed.clone(),
-        None => bail!(
-            "Couldnt find the location {} in the consistent_parts map",
-            location.get_id()
-        ),
-    };
+    let cons_fed = open!(
+        consistent_parts.get(location.get_id()).cloned(),
+        "Couldn't find the location {} in the consistent_parts map",
+        location.get_id()
+    )?;
 
     let mut changed = false;
     for edge in &mut new_comp.edges {

--- a/src/System/pruning.rs
+++ b/src/System/pruning.rs
@@ -127,11 +127,7 @@ fn is_inconsistent(
         Federation::new(vec![], dimensions)
     };
 
-    let cons_fed = open!(
-        consistent_parts.get(location.get_id()),
-        "Couldn't find the location {} in the consistent_parts map",
-        location.get_id()
-    )?;
+    let cons_fed = open!(consistent_parts.get(location.get_id()))?;
 
     //Returns whether the consistent part is strictly less than the zone induced by the invariant
     Ok(cons_fed.is_subset_eq(&inv_fed) && !inv_fed.is_subset_eq(&cons_fed))
@@ -147,11 +143,7 @@ fn prune_to_consistent_part(
     if !is_inconsistent(location, consistent_parts, decls, dimensions)? {
         return Ok(false);
     }
-    let cons_fed = open!(
-        consistent_parts.get(location.get_id()).cloned(),
-        "Couldn't find the location {} in the consistent_parts map",
-        location.get_id()
-    )?;
+    let cons_fed = open!(consistent_parts.get(location.get_id()).cloned())?;
 
     let mut changed = false;
     for edge in &mut new_comp.edges {

--- a/src/System/pruning.rs
+++ b/src/System/pruning.rs
@@ -1,4 +1,4 @@
-use crate::open;
+use crate::to_result;
 use crate::DBMLib::dbm::{Federation, Zone};
 use crate::EdgeEval::constraint_applyer::apply_constraint;
 use crate::ModelObjects::component::{Component, Declarations, Edge, Location, SyncType};
@@ -127,7 +127,7 @@ fn is_inconsistent(
         Federation::new(vec![], dimensions)
     };
 
-    let cons_fed = open!(consistent_parts.get(location.get_id()))?;
+    let cons_fed = to_result!(consistent_parts.get(location.get_id()))?;
 
     //Returns whether the consistent part is strictly less than the zone induced by the invariant
     Ok(cons_fed.is_subset_eq(&inv_fed) && !inv_fed.is_subset_eq(&cons_fed))
@@ -143,7 +143,7 @@ fn prune_to_consistent_part(
     if !is_inconsistent(location, consistent_parts, decls, dimensions)? {
         return Ok(false);
     }
-    let cons_fed = open!(consistent_parts.get(location.get_id()).cloned())?;
+    let cons_fed = to_result!(consistent_parts.get(location.get_id()).cloned())?;
 
     let mut changed = false;
     for edge in &mut new_comp.edges {

--- a/src/System/refine.rs
+++ b/src/System/refine.rs
@@ -1,16 +1,16 @@
+use crate::bail;
 use crate::DBMLib::dbm::Federation;
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 use crate::ModelObjects::component::Transition;
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::statepair::StatePair;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
-use simple_error::bail;
-use std::error::Error;
+use anyhow::Result;
 
 pub fn check_refinement(
     mut sys1: TransitionSystemPtr,
     mut sys2: TransitionSystemPtr,
-) -> Result<Result<bool, String>, Box<dyn Error>> {
+) -> Result<Result<bool, String>> {
     let mut passed_list: Vec<StatePair> = vec![];
     let mut waiting_list: Vec<StatePair> = vec![];
     // Add extra inputs/outputs
@@ -134,7 +134,7 @@ fn has_valid_state_pair<'a>(
     transitions2: &[Transition<'a>],
     curr_pair: &StatePair<'a>,
     is_state1: bool,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     let dim = curr_pair.zone.dimension;
 
     let (states1, states2) = curr_pair.get_locations(is_state1);
@@ -176,7 +176,7 @@ fn create_new_state_pairs<'a>(
     passed_list: &mut Vec<StatePair<'a>>,
     max_bounds: &MaxBounds,
     is_state1: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     for transition1 in transitions1 {
         for transition2 in transitions2 {
             //We currently don't use the bool returned here for anything
@@ -203,7 +203,7 @@ fn build_state_pair<'a>(
     passed_list: &mut Vec<StatePair<'a>>,
     max_bounds: &MaxBounds,
     is_state1: bool,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     //Creates new state pair
     let mut new_sp: StatePair = StatePair::create(
         curr_pair.get_dimensions(),
@@ -273,7 +273,7 @@ fn prepare_init_state<'a>(
     initial_locations_1: LocationTuple<'a>,
     initial_locations_2: LocationTuple<'a>,
     dimensions: u32,
-) -> Result<StatePair<'a>, Box<dyn Error>> {
+) -> Result<StatePair<'a>> {
     let mut initial_pair = StatePair::create(
         dimensions,
         initial_locations_1.clone(),
@@ -311,7 +311,7 @@ fn check_preconditions(
     sys1: &TransitionSystemPtr,
     sys2: &TransitionSystemPtr,
     dim: u32,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     if !(sys2.precheck_sys_rep(dim)? && sys1.precheck_sys_rep(dim)?) {
         return Ok(false);
     }
@@ -351,7 +351,7 @@ fn check_preconditions(
 fn is_new_state<'a>(
     state_pair: &mut StatePair<'a>,
     passed_list: &mut Vec<StatePair<'a>>,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     'OuterFor: for passed_state_pair in passed_list {
         /*if passed_state_pair.get_locations1().len() != state_pair.get_locations1().len() {
             panic!("states should always have same length")

--- a/src/System/save_component.rs
+++ b/src/System/save_component.rs
@@ -3,10 +3,10 @@ use crate::ModelObjects::component::{
 };
 use crate::ModelObjects::representations::BoolExpression;
 use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
+use anyhow::Result;
 use std::collections::HashMap;
-use std::error::Error;
 
-pub fn combine_components(system: &TransitionSystemPtr) -> Result<Component, Box<dyn Error>> {
+pub fn combine_components(system: &TransitionSystemPtr) -> Result<Component> {
     let mut location_tuples = vec![];
     let mut edges = vec![];
     let clocks = get_clock_map(system)?;
@@ -29,7 +29,7 @@ pub fn combine_components(system: &TransitionSystemPtr) -> Result<Component, Box
 fn get_locations_from_tuples(
     location_tuples: &Vec<LocationTuple>,
     clock_map: &HashMap<String, u32>,
-) -> Result<Vec<Location>, Box<dyn Error>> {
+) -> Result<Vec<Location>> {
     let mut result = vec![];
 
     for loc_vec in location_tuples.iter() {
@@ -63,7 +63,7 @@ fn get_locations_from_tuples(
     Ok(result)
 }
 
-fn get_clock_map(sysrep: &TransitionSystemPtr) -> Result<HashMap<String, u32>, Box<dyn Error>> {
+fn get_clock_map(sysrep: &TransitionSystemPtr) -> Result<HashMap<String, u32>> {
     let mut clocks = HashMap::new();
 
     if let Some(initial) = sysrep.get_all_locations().first() {
@@ -84,7 +84,7 @@ fn collect_all_edges_and_locations<'a>(
     locations: &mut Vec<LocationTuple<'a>>,
     edges: &mut Vec<Edge>,
     clock_map: &HashMap<String, u32>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let l = representation.get_all_locations();
     locations.extend(l);
     for location in locations {
@@ -98,7 +98,7 @@ fn collect_edges_from_location<'a>(
     representation: &TransitionSystemPtr,
     edges: &mut Vec<Edge>,
     clock_map: &HashMap<String, u32>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     collect_specific_edges_from_location(location, representation, edges, true, clock_map)?;
     collect_specific_edges_from_location(location, representation, edges, false, clock_map)?;
 
@@ -111,7 +111,7 @@ fn collect_specific_edges_from_location<'a>(
     edges: &mut Vec<Edge>,
     input: bool,
     clock_map: &HashMap<String, u32>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     for sync in if input {
         representation.get_input_actions()?
     } else {

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -5,10 +5,10 @@ macro_rules! default_composition {
             bounds.add_bounds(&self.right.get_max_bounds(dim));
             bounds
         }
-        fn get_input_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+        fn get_input_actions(&self) -> Result<HashSet<String>> {
             Ok(self.inputs.clone())
         }
-        fn get_output_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+        fn get_output_actions(&self) -> Result<HashSet<String>> {
             Ok(self.outputs.clone())
         }
         fn get_num_clocks(&self) -> u32 {
@@ -52,7 +52,7 @@ macro_rules! default_composition {
             )
         }
 
-        fn precheck_sys_rep(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+        fn precheck_sys_rep(&self, dim: u32) -> Result<bool> {
             if !self.is_deterministic(dim)? {
                 println!("NOT DETERMINISTIC");
                 return Ok(false);
@@ -66,11 +66,11 @@ macro_rules! default_composition {
             Ok(true)
         }
 
-        fn is_deterministic(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+        fn is_deterministic(&self, dim: u32) -> Result<bool> {
             Ok(self.left.is_deterministic(dim)? && self.right.is_deterministic(dim)?)
         }
 
-        fn get_initial_state(&self, dimensions: u32) -> Result<State, Box<dyn Error>> {
+        fn get_initial_state(&self, dimensions: u32) -> Result<State> {
             let init_loc = match self.get_initial_location() {
                 Some(init_loc) => init_loc,
                 None => bail!("Cannot create initial state as there is no initial location"),

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -71,10 +71,7 @@ macro_rules! default_composition {
         }
 
         fn get_initial_state(&self, dimensions: u32) -> Result<State> {
-            let init_loc = open!(
-                self.get_initial_location(),
-                "Cannot create initial state as there is no initial location"
-            )?;
+            let init_loc = open!(self.get_initial_location())?;
             let mut zone = Zone::init(dimensions);
             if !init_loc.apply_invariants(&mut zone)? {
                 bail!("Invalid starting state");

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -71,10 +71,10 @@ macro_rules! default_composition {
         }
 
         fn get_initial_state(&self, dimensions: u32) -> Result<State> {
-            let init_loc = match self.get_initial_location() {
-                Some(init_loc) => init_loc,
-                None => bail!("Cannot create initial state as there is no initial location"),
-            };
+            let init_loc = open!(
+                self.get_initial_location(),
+                "Cannot create initial state as there is no initial location"
+            )?;
             let mut zone = Zone::init(dimensions);
             if !init_loc.apply_invariants(&mut zone)? {
                 bail!("Invalid starting state");

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -71,7 +71,7 @@ macro_rules! default_composition {
         }
 
         fn get_initial_state(&self, dimensions: u32) -> Result<State> {
-            let init_loc = open!(self.get_initial_location())?;
+            let init_loc = to_result!(self.get_initial_location())?;
             let mut zone = Zone::init(dimensions);
             if !init_loc.apply_invariants(&mut zone)? {
                 bail!("Invalid starting state");

--- a/src/TransitionSystems/composition.rs
+++ b/src/TransitionSystems/composition.rs
@@ -1,11 +1,11 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use simple_error::bail;
+use anyhow::Result;
 use std::collections::hash_set::HashSet;
-use std::error::Error;
 
 #[derive(Clone)]
 pub struct Composition {
@@ -16,10 +16,7 @@ pub struct Composition {
 }
 
 impl Composition {
-    pub fn new(
-        left: TransitionSystemPtr,
-        right: TransitionSystemPtr,
-    ) -> Result<Box<Composition>, Box<dyn Error>> {
+    pub fn new(left: TransitionSystemPtr, right: TransitionSystemPtr) -> Result<Box<Composition>> {
         let left_out = left.get_output_actions()?;
         let right_out = right.get_output_actions()?;
 
@@ -59,7 +56,7 @@ impl<'a> TransitionSystem<'static> for Composition {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         let mut transitions = vec![];
 
         let mut left = self
@@ -79,7 +76,7 @@ impl<'a> TransitionSystem<'static> for Composition {
         Ok(transitions)
     }
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool> {
         Ok(
             local_consistency::is_least_consistent(self.left.as_ref(), dimensions)?
                 && local_consistency::is_least_consistent(self.right.as_ref(), dimensions)?,

--- a/src/TransitionSystems/composition.rs
+++ b/src/TransitionSystems/composition.rs
@@ -1,9 +1,9 @@
-use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
+use crate::{bail, open};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/composition.rs
+++ b/src/TransitionSystems/composition.rs
@@ -3,7 +3,7 @@ use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/conjunction.rs
+++ b/src/TransitionSystems/conjunction.rs
@@ -1,10 +1,10 @@
-use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::System::pruning;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
+use crate::{bail, open};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/conjunction.rs
+++ b/src/TransitionSystems/conjunction.rs
@@ -1,12 +1,12 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::System::pruning;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use simple_error::bail;
+use anyhow::Result;
 use std::collections::hash_set::HashSet;
-use std::error::Error;
 
 #[derive(Clone)]
 pub struct Conjunction {
@@ -20,7 +20,7 @@ impl Conjunction {
     pub fn new(
         left: TransitionSystemPtr,
         right: TransitionSystemPtr,
-    ) -> Result<TransitionSystemPtr, Box<dyn Error>> {
+    ) -> Result<TransitionSystemPtr> {
         let outputs = left
             .get_output_actions()?
             .intersection(&right.get_output_actions()?)
@@ -52,7 +52,7 @@ impl<'a> TransitionSystem<'static> for Conjunction {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         let mut left = self
             .left
             .next_transitions(location, action, sync_type, index)?;
@@ -63,7 +63,7 @@ impl<'a> TransitionSystem<'static> for Conjunction {
         Ok(Transition::combinations(&mut left, &mut right))
     }
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool> {
         local_consistency::is_least_consistent(self, dimensions)
     }
 }
@@ -76,11 +76,11 @@ pub struct PrunedComponent {
 }
 
 impl<'a> TransitionSystem<'static> for PrunedComponent {
-    fn get_input_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+    fn get_input_actions(&self) -> Result<HashSet<String>> {
         Ok(self.inputs.clone())
     }
 
-    fn get_output_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+    fn get_output_actions(&self) -> Result<HashSet<String>> {
         Ok(self.outputs.clone())
     }
 
@@ -119,24 +119,24 @@ impl<'a> TransitionSystem<'static> for PrunedComponent {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         self.component
             .next_transitions(location, action, sync_type, index)
     }
 
-    fn precheck_sys_rep(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+    fn precheck_sys_rep(&self, dim: u32) -> Result<bool> {
         self.component.precheck_sys_rep(dim)
     }
 
-    fn is_deterministic(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_deterministic(&self, dim: u32) -> Result<bool> {
         self.component.is_deterministic(dim)
     }
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool> {
         self.component.is_locally_consistent(dimensions)
     }
 
-    fn get_initial_state(&self, dimensions: u32) -> Result<State, Box<dyn Error>> {
+    fn get_initial_state(&self, dimensions: u32) -> Result<State> {
         self.component.get_initial_state(dimensions)
     }
 }

--- a/src/TransitionSystems/conjunction.rs
+++ b/src/TransitionSystems/conjunction.rs
@@ -4,7 +4,7 @@ use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::System::pruning;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/quotient.rs
+++ b/src/TransitionSystems/quotient.rs
@@ -1,9 +1,9 @@
-use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
+use crate::{bail, open};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/quotient.rs
+++ b/src/TransitionSystems/quotient.rs
@@ -3,7 +3,7 @@ use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use std::collections::hash_set::HashSet;
 

--- a/src/TransitionSystems/quotient.rs
+++ b/src/TransitionSystems/quotient.rs
@@ -1,11 +1,11 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{Component, State, SyncType, Transition};
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
-use simple_error::bail;
+use anyhow::Result;
 use std::collections::hash_set::HashSet;
-use std::error::Error;
 
 #[derive(Clone)]
 pub struct Quotient {
@@ -29,11 +29,11 @@ impl TransitionSystem<'static> for Quotient {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         panic!("Not implemented");
     }
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool> {
         local_consistency::is_least_consistent(self, dimensions)
     }
 }

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -18,19 +18,11 @@ pub struct LocationTuple<'a> {
 
 impl<'a> LocationTuple<'a> {
     pub fn get_location(&self, index: usize) -> Result<&Location> {
-        open!(
-            self.locations.get(index).copied(),
-            "Index {} out of bounds during location tuple access for location",
-            index
-        )
+        open!(self.locations.get(index).copied())
     }
 
     pub fn get_decl(&self, index: usize) -> Result<&Declarations> {
-        open!(
-            self.declarations.get(index),
-            "Index {} out of bounds during location tuple access for declarations",
-            index
-        )
+        open!(self.declarations.get(index))
     }
 
     pub fn set_location(&mut self, index: usize, new_loc: &'a Location) {
@@ -234,13 +226,8 @@ impl TransitionSystem<'_> for Component {
     }
 
     fn get_initial_state(&self, dimensions: u32) -> Result<State> {
-        let init_loc = LocationTuple::simple(
-            open!(
-                self.get_initial_location(),
-                "Cannot create initial state because there exists no initial location"
-            )?,
-            self.get_declarations(),
-        );
+        let init_loc =
+            LocationTuple::simple(open!(self.get_initial_location())?, self.get_declarations());
         let mut zone = Zone::init(dimensions);
         if !init_loc.apply_invariants(&mut zone)? {
             bail!("Invalid starting state");

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -5,7 +5,7 @@ use crate::ModelObjects::component::{
 };
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
-use crate::{bail, open};
+use crate::{bail, to_result};
 use anyhow::Result;
 use dyn_clone::{clone_trait_object, DynClone};
 use std::collections::hash_set::HashSet;
@@ -18,11 +18,11 @@ pub struct LocationTuple<'a> {
 
 impl<'a> LocationTuple<'a> {
     pub fn get_location(&self, index: usize) -> Result<&Location> {
-        open!(self.locations.get(index).copied())
+        to_result!(self.locations.get(index).copied())
     }
 
     pub fn get_decl(&self, index: usize) -> Result<&Declarations> {
-        open!(self.declarations.get(index))
+        to_result!(self.declarations.get(index))
     }
 
     pub fn set_location(&mut self, index: usize, new_loc: &'a Location) {
@@ -226,8 +226,10 @@ impl TransitionSystem<'_> for Component {
     }
 
     fn get_initial_state(&self, dimensions: u32) -> Result<State> {
-        let init_loc =
-            LocationTuple::simple(open!(self.get_initial_location())?, self.get_declarations());
+        let init_loc = LocationTuple::simple(
+            to_result!(self.get_initial_location())?,
+            self.get_declarations(),
+        );
         let mut zone = Zone::init(dimensions);
         if !init_loc.apply_invariants(&mut zone)? {
             bail!("Invalid starting state");

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -1,3 +1,4 @@
+use crate::bail;
 use crate::DBMLib::dbm::Zone;
 use crate::ModelObjects::component::{
     Channel, Component, DeclarationProvider, Declarations, DecoratedLocation, Location, State,
@@ -5,10 +6,9 @@ use crate::ModelObjects::component::{
 };
 use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::System::local_consistency;
+use anyhow::Result;
 use dyn_clone::{clone_trait_object, DynClone};
-use simple_error::bail;
 use std::collections::hash_set::HashSet;
-use std::error::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocationTuple<'a> {
@@ -17,14 +17,14 @@ pub struct LocationTuple<'a> {
 }
 
 impl<'a> LocationTuple<'a> {
-    pub fn get_location(&self, index: usize) -> Result<&Location, Box<dyn Error>> {
+    pub fn get_location(&self, index: usize) -> Result<&Location> {
         match self.locations.get(index) {
             Some(loc) => Ok(loc),
             None => bail!("Index out of bounds during location tuple access for location"),
         }
     }
 
-    pub fn get_decl(&self, index: usize) -> Result<&Declarations, Box<dyn Error>> {
+    pub fn get_decl(&self, index: usize) -> Result<&Declarations> {
         match self.declarations.get(index) {
             Some(decl) => Ok(decl),
             None => bail!("Index out of bounds during location tuple access for declarations"),
@@ -78,7 +78,7 @@ impl<'a> LocationTuple<'a> {
         self.locations.iter().zip(self.declarations.iter())
     }
 
-    pub fn apply_invariants(&self, zone: &mut Zone) -> Result<bool, Box<dyn Error>> {
+    pub fn apply_invariants(&self, zone: &mut Zone) -> Result<bool> {
         let mut success = true;
 
         for (location, decl) in self.locations.iter().zip(self.declarations.iter()) {
@@ -99,13 +99,13 @@ pub trait TransitionSystem<'a>: DynClone {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>>;
+    ) -> Result<Vec<Transition<'b>>>;
 
     fn next_outputs<'b>(
         &'b self,
         location: &LocationTuple<'b>,
         action: &str,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         let mut index = 0;
         self.next_transitions(location, action, &SyncType::Output, &mut index)
     }
@@ -114,14 +114,14 @@ pub trait TransitionSystem<'a>: DynClone {
         &'b self,
         location: &LocationTuple<'b>,
         action: &str,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         let mut index = 0;
         self.next_transitions(location, action, &SyncType::Input, &mut index)
     }
 
-    fn get_input_actions(&self) -> Result<HashSet<String>, Box<dyn Error>>;
+    fn get_input_actions(&self) -> Result<HashSet<String>>;
 
-    fn get_output_actions(&self) -> Result<HashSet<String>, Box<dyn Error>>;
+    fn get_output_actions(&self) -> Result<HashSet<String>>;
 
     fn get_initial_location<'b>(&'b self) -> Option<LocationTuple<'b>>;
 
@@ -131,17 +131,17 @@ pub trait TransitionSystem<'a>: DynClone {
 
     fn get_components<'b>(&'b self) -> Vec<&'b Component>;
 
-    fn precheck_sys_rep(&self, dim: u32) -> Result<bool, Box<dyn Error>>;
+    fn precheck_sys_rep(&self, dim: u32) -> Result<bool>;
 
     fn initialize(&mut self, dimensions: u32) {}
 
-    fn is_deterministic(&self, dim: u32) -> Result<bool, Box<dyn Error>>;
+    fn is_deterministic(&self, dim: u32) -> Result<bool>;
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>>;
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool>;
 
     fn set_clock_indices(&mut self, index: &mut u32);
 
-    fn get_initial_state(&self, dimensions: u32) -> Result<State, Box<dyn Error>>;
+    fn get_initial_state(&self, dimensions: u32) -> Result<State>;
 
     fn get_max_clock_index(&self) -> u32;
 }
@@ -167,13 +167,13 @@ impl TransitionSystem<'_> for Component {
         self.get_max_bounds(dim)
     }
 
-    fn get_input_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+    fn get_input_actions(&self) -> Result<HashSet<String>> {
         let channels: Vec<Channel> = self.get_input_actions()?;
 
         Ok(channels.into_iter().map(|c| c.name).collect())
     }
 
-    fn get_output_actions(&self) -> Result<HashSet<String>, Box<dyn Error>> {
+    fn get_output_actions(&self) -> Result<HashSet<String>> {
         let channels: Vec<Channel> = self.get_output_actions()?;
 
         Ok(channels.into_iter().map(|c| c.name).collect())
@@ -203,7 +203,7 @@ impl TransitionSystem<'_> for Component {
         action: &str,
         sync_type: &SyncType,
         index: &mut usize,
-    ) -> Result<Vec<Transition<'b>>, Box<dyn Error>> {
+    ) -> Result<Vec<Transition<'b>>> {
         let location = location.get_location(*index)?;
         let next_edges = self.get_next_edges(location, action, *sync_type)?;
 
@@ -219,19 +219,19 @@ impl TransitionSystem<'_> for Component {
         Ok(open_transitions)
     }
 
-    fn precheck_sys_rep(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+    fn precheck_sys_rep(&self, dim: u32) -> Result<bool> {
         self.check_consistency(dim, true)
     }
 
-    fn is_deterministic(&self, dim: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_deterministic(&self, dim: u32) -> Result<bool> {
         Component::is_deterministic(self, dim)
     }
 
-    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool, Box<dyn Error>> {
+    fn is_locally_consistent(&self, dimensions: u32) -> Result<bool> {
         local_consistency::is_least_consistent(self, dimensions)
     }
 
-    fn get_initial_state(&self, dimensions: u32) -> Result<State, Box<dyn Error>> {
+    fn get_initial_state(&self, dimensions: u32) -> Result<State> {
         let init_loc = LocationTuple::simple(
             match self.get_initial_location() {
                 Some(init_loc) => init_loc,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use crate::ModelObjects::queries::Query;
 use crate::System::extract_system_rep;
 use anyhow::{Context, Result};
 use clap::{load_yaml, App};
-use std::error::Error;
 use ModelObjects::component;
 use ModelObjects::queries;
 use ProtobufServer::start_grpc_server_with_tokio;
@@ -53,7 +52,10 @@ fn main() -> Result<()> {
     let matches = App::from(yaml).get_matches();
 
     if let Some(ip_endpoint) = matches.value_of("endpoint") {
-        start_grpc_server_with_tokio(ip_endpoint)?;
+        info!(
+            start_grpc_server_with_tokio(ip_endpoint),
+            "Failed to start GRPC server"
+        );
     } else {
         start_using_cli(&matches);
     }
@@ -85,7 +87,7 @@ fn start_using_cli(matches: &clap::ArgMatches) {
 fn create_and_execute(
     query: &Query,
     project_loader: &mut Box<dyn ComponentLoader>,
-) -> Result<QueryResult, Box<dyn Error>> {
+) -> Result<QueryResult> {
     let executable_query = Box::new(extract_system_rep::create_executable_query(
         query,
         &mut **project_loader,
@@ -108,7 +110,7 @@ fn try_parse_args(matches: &clap::ArgMatches) -> (Box<dyn ComponentLoader>, Vec<
 
 fn parse_args(
     matches: &clap::ArgMatches,
-) -> Result<(Box<dyn ComponentLoader>, Vec<queries::Query>), Box<dyn Error>> {
+) -> Result<(Box<dyn ComponentLoader>, Vec<queries::Query>)> {
     let mut folder_path: String = "".to_string();
     let mut query = "".to_string();
 
@@ -133,7 +135,7 @@ fn parse_args(
     }
 }
 
-fn get_project_loader(project_path: String) -> Result<Box<dyn ProjectLoader>, Box<dyn Error>> {
+fn get_project_loader(project_path: String) -> Result<Box<dyn ProjectLoader>> {
     if xml_parser::is_xml_project(&project_path) {
         XmlProjectLoader::new(project_path)
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
     let matches = App::from(yaml).get_matches();
 
     if let Some(ip_endpoint) = matches.value_of("endpoint") {
-        info!(
+        context!(
             start_grpc_server_with_tokio(ip_endpoint),
             "Failed to start GRPC server"
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod DBMLib;
 mod DataReader;
 mod EdgeEval;
+mod Macros;
 mod ModelObjects;
 mod ProtobufServer;
 mod System;
@@ -15,7 +16,7 @@ use crate::DataReader::component_loader::{
 use crate::DataReader::{parse_queries, xml_parser};
 use crate::ModelObjects::queries::Query;
 use crate::System::extract_system_rep;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{load_yaml, App};
 use ModelObjects::component;
 use ModelObjects::queries;
@@ -31,22 +32,6 @@ extern crate serde_xml_rs;
 extern crate simple_error;
 extern crate xml;
 
-#[doc(hidden)]
-pub fn _add_info_to_result<T>(res: Result<T>, info: String) -> Result<T> {
-    res.with_context(|| info)
-}
-
-#[macro_export]
-macro_rules! info {
-    ($result:expr) => { info!($result, "") };
-    ($result:expr, $($args:expr ),*) => { $crate::_add_info_to_result($result, format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))? };
-}
-
-#[macro_export]
-macro_rules! bail {
-    ($($args:expr ),*) => {$crate::anyhow::bail!(format!("{}: {}", concat!(file!(), ":", line!(), ":", column!()) ,format!( $( $args ),* )))}
-}
-
 fn main() -> Result<()> {
     let yaml = load_yaml!("cli.yml");
     let matches = App::from(yaml).get_matches();
@@ -55,7 +40,7 @@ fn main() -> Result<()> {
         info!(
             start_grpc_server_with_tokio(ip_endpoint),
             "Failed to start GRPC server"
-        );
+        )?;
     } else {
         start_using_cli(&matches);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ extern crate anyhow;
 extern crate colored;
 extern crate serde;
 extern crate serde_xml_rs;
-extern crate simple_error;
 extern crate xml;
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Changes all results to `anyhow::Result`, allowing us to avoid typing `Result<T, dyn Error...>` and instead type `Result<T>`. Furthermore anyhow results can carry a context which contains a 'stack trace' for errors. Here is an example of starting the grpc server with a wrong ip address:
![image](https://user-images.githubusercontent.com/17483094/162431403-01138ea7-1a3c-4739-b7c6-5602244d0737.png)

The PR introduces a few new macros to add information to results:
- `info!` adds file and line information to an `anyhow::Result` with the option of adding additional context, the macro automatically formats so `info!(result, "{:?}", var)` and `info!(result, "Failed because ...")` work as expected.
- `into_info!` works as `info!` but first converts the result into an `anyhow:Result`, useful for when we call external libraries with new result types such as Serde and others. 
- `bail!` works like the standard bail but adds file and line information.
- `open!` converts options to results with file and line information, optionally adds additional context as in `info!`. Example: ``let thing : Option<T> = ...;
let var = open!(thing, "Failed to open thing")?``
- `error!` constructs an anyhow::Error with file and line information and context.

If you have better ideas for naming of macros I'm open for suggestions.
`open!` could for example be `try_unwrap!` if we want a longer name.