### PR TITLE
Stop build script from running when no files are changed

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -12,7 +12,8 @@ fn main() {
     }
 
     tonic_build::compile_protos("Ecdar-ProtoBuf/services.proto").unwrap();
-    println!("cargo:rerun-if-changed=Ecdar-ProtoBuf/*.proto");
+    // Tell cargo to invalidate the crate when the protobuf repository changes
+    println!("cargo:rerun-if-changed=Ecdar-ProtoBuf");
 
     let host = std::env::var("HOST").unwrap();
     let target = std::env::var("TARGET").unwrap();


### PR DESCRIPTION
On the master branch the build script is run every time cargo compiles because a `cargo:rerun-if-changed` used a `*`-wildcard. With this change it only runs when either the ProtoBuf or the wrapper changes.

Reduces the runtime of `cargo check`  by 2x on my machine, and cuts some seconds off `cargo build`.