### PR TITLE
Catch unwinding panics when using the GRPC protocol to return more informative errors to users 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ build = "src/build.rs"
 authors = ["Peter Greve <Pgreve16@student.aau.dk>"]
 edition = "2018"
 
+[target.x86_64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment"]
+
 [features]
 dbm-stub = []
 verbose = []
@@ -29,6 +33,7 @@ prost = "0.8.*"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 colored = "2.0.0"
 simple-error = "0.2.3"
+futures = "0.3.21"
 
 
 [build-dependencies]

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -1,7 +1,9 @@
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackend;
 
 use crate::ProtobufServer::services::{ComponentsUpdateRequest, Query, QueryResponse};
+use futures::FutureExt;
 use std::cell::RefCell;
+use std::panic::UnwindSafe;
 use std::sync::{Mutex, MutexGuard};
 use tonic::{Request, Response, Status};
 
@@ -23,16 +25,41 @@ impl ConcreteEcdarBackend {
     }
 }
 
+async fn catch_unwind<T, O>(future: T) -> Result<O, Status>
+where
+    T: UnwindSafe + futures::Future<Output = Result<O, Status>>,
+{
+    fn downcast_to_string(e: Box<dyn std::any::Any + Send>) -> String {
+        match e.downcast::<String>() {
+            Ok(v) => *v,
+            Err(e) => match e.downcast::<&str>() {
+                Ok(v) => v.to_string(),
+                _ => "Unknown Source of Error".to_owned(),
+            },
+        }
+    }
+
+    return match future.catch_unwind().await {
+        Ok(response) => response,
+        Err(e) => Err(Status::unknown(format!(
+            "{}, please report this bug to the developers",
+            downcast_to_string(e)
+        ))),
+    };
+}
+
 #[tonic::async_trait]
 impl EcdarBackend for ConcreteEcdarBackend {
     async fn send_query(&self, request: Request<Query>) -> Result<Response<QueryResponse>, Status> {
-        self.handle_send_query(request).await
+        let request = std::panic::AssertUnwindSafe(request);
+        catch_unwind(self.handle_send_query(request)).await
     }
 
     async fn update_components(
         &self,
         request: Request<ComponentsUpdateRequest>,
     ) -> Result<Response<()>, tonic::Status> {
-        self.handle_update_components(request).await
+        let request = std::panic::AssertUnwindSafe(request);
+        catch_unwind(self.handle_update_components(request)).await
     }
 }

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -41,7 +41,7 @@ where
 
     return match future.catch_unwind().await {
         Ok(response) => response,
-        Err(e) => Err(Status::unknown(format!(
+        Err(e) => Err(Status::internal(format!(
             "{}, please report this bug to the developers",
             downcast_to_string(e)
         ))),

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -38,7 +38,7 @@ impl ConcreteEcdarBackend {
         let executable_query =
             match extract_system_rep::create_executable_query(&query, &mut *component_container) {
                 Ok(query) => query,
-                Err(e) => return Err(Status::internal(format!("Creation of query failed: {}", e))),
+                Err(e) => return Err(Status::invalid_argument(format!("Creation of query failed: {}", e))),
             };
         let result = executable_query.execute();
 

--- a/src/ProtobufServer/ecdar_requests/update_components.rs
+++ b/src/ProtobufServer/ecdar_requests/update_components.rs
@@ -9,14 +9,15 @@ use crate::ProtobufServer::services::{Component as ProtobufComponent, Components
 use crate::ProtobufServer::ConcreteEcdarBackend;
 use crate::System::input_enabler;
 use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
 use tonic::{Request, Response};
 
 impl ConcreteEcdarBackend {
     pub async fn handle_update_components(
         &self,
-        request: Request<ComponentsUpdateRequest>,
+        request: AssertUnwindSafe<Request<ComponentsUpdateRequest>>,
     ) -> Result<Response<()>, tonic::Status> {
-        let update = request.into_inner();
+        let update = request.0.into_inner();
 
         let component_container = self.get_components_lock()?;
         for proto_component in &update.components {


### PR DESCRIPTION
This allows us to use panic _sometimes_ when something is actually unexpected. 
For expected errors, e.g. user input, we should still introduce relevant informative results (as in the results refactor PRs).

Works by catching unwinding panics with `catch_unwind()` on async futures, the error message is not always that informative but it is better than crashing the application with no information at all.

If users encounter such errors they can report them to us and we can run the query ourselves to get the stacktrace of the panic and fix the bug.