### PR TITLE
Allow for local max bounds in transition systems to get earlier extrapolation

### DIFF
--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -12,8 +12,8 @@ use crate::ModelObjects::max_bounds::MaxBounds;
 use crate::ModelObjects::representations;
 
 use crate::ModelObjects::representations::BoolExpression;
-use crate::TransitionSystems::LocationTuple;
-use crate::TransitionSystems::{CompositionType, LocationID};
+use crate::TransitionSystems::{CompositionType, LocationID, TransitionSystem};
+use crate::TransitionSystems::{LocationTuple, TransitionSystemPtr};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -518,6 +518,11 @@ impl State {
 
     pub fn get_location(&self) -> &LocationTuple {
         &self.decorated_locations
+    }
+
+    pub fn extrapolate_max_bounds(&mut self, system: &dyn TransitionSystem) {
+        let bounds = system.get_local_max_bounds(&self.decorated_locations);
+        self.zone.extrapolate_max_bounds(&bounds);
     }
 }
 

--- a/src/ModelObjects/statepair.rs
+++ b/src/ModelObjects/statepair.rs
@@ -55,17 +55,14 @@ impl StatePair {
         }
     }
 
-    pub fn calculate_max_bound(
+    pub fn extrapolate_max_bounds(
         &mut self,
         sys1: &TransitionSystemPtr,
         sys2: &TransitionSystemPtr,
-    ) -> MaxBounds {
-        let dim = self.zone.get_dimensions();
-
-        let mut bounds = sys1.get_max_bounds();
-        bounds.add_bounds(&sys2.get_max_bounds());
-
-        bounds
+    ) {
+        let mut bounds = sys1.get_local_max_bounds(&self.locations1);
+        bounds.add_bounds(&sys2.get_local_max_bounds(&self.locations2));
+        self.zone.extrapolate_max_bounds(&bounds);
     }
 }
 

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -4,11 +4,6 @@ macro_rules! default_composition {
             self.dim
         }
 
-        fn get_max_bounds(&self) -> MaxBounds {
-            let mut bounds = self.left.get_max_bounds();
-            bounds.add_bounds(&self.right.get_max_bounds());
-            bounds
-        }
         fn get_input_actions(&self) -> HashSet<String> {
             self.inputs.clone()
         }
@@ -21,6 +16,21 @@ macro_rules! default_composition {
                 .map(|action| action.to_string())
                 .collect()
         }
+
+        fn get_local_max_bounds(&self, loc: &LocationTuple) -> MaxBounds {
+            if loc.is_universal() || loc.is_inconsistent() {
+                MaxBounds::create(self.get_dim())
+            } else {
+                let (left, right) = self.get_children();
+                let loc_l = loc.get_left();
+                let loc_r = loc.get_right();
+                let mut bounds_l = left.get_local_max_bounds(loc_l);
+                let bounds_r = right.get_local_max_bounds(loc_r);
+                bounds_l.add_bounds(&bounds_r);
+                bounds_l
+            }
+        }
+
         fn get_initial_location(&self) -> Option<LocationTuple> {
             let (left, right) = self.get_children();
             let l = left.get_initial_location()?;

--- a/src/TransitionSystems/compiled_component.rs
+++ b/src/TransitionSystems/compiled_component.rs
@@ -101,16 +101,20 @@ impl CompiledComponent {
 }
 
 impl TransitionSystem for CompiledComponent {
+    fn get_local_max_bounds(&self, loc: &LocationTuple) -> MaxBounds {
+        if loc.is_universal() || loc.is_inconsistent() {
+            MaxBounds::create(self.get_dim())
+        } else {
+            self.comp_info.max_bounds.clone()
+        }
+    }
+
     fn get_composition_type(&self) -> CompositionType {
         panic!("Components do not have a composition type")
     }
 
     fn get_decls(&self) -> Vec<&Declarations> {
         vec![&self.comp_info.declarations]
-    }
-
-    fn get_max_bounds(&self) -> MaxBounds {
-        self.comp_info.max_bounds.clone()
     }
 
     fn get_input_actions(&self) -> HashSet<String> {

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -7,7 +7,7 @@ use std::collections::hash_set::HashSet;
 pub type TransitionSystemPtr = Box<dyn TransitionSystem>;
 
 pub trait TransitionSystem: DynClone {
-    fn get_max_bounds(&self) -> MaxBounds;
+    fn get_local_max_bounds(&self, loc: &LocationTuple) -> MaxBounds;
 
     fn get_dim(&self) -> u32;
 


### PR DESCRIPTION
Currently just improves extrapolation in universal and inconsistent locations, which reduces the statespace of quotient queries a lot. 
Implementation is general enough to allow CompiledComponents to have different local bounds for each location