### PR TITLE
Add benchmarking with Criterion and logging with various levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2018"
 name = "reveaal"
 path = "src/lib.rs"
 
+[[bin]]
+name = "Reveaal"
+path = "src/main.rs"
+
 [features]
 default = ["logging"]
 logging = ["dep:env_logger", "dep:chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,8 @@ name = "reveaal"
 path = "src/lib.rs"
 
 [features]
-dbm-stub = []
-verbose = []
-single-threaded = []
+default = ["logging"]
+logging = ["dep:env_logger", "dep:chrono"]
 
 [dependencies]
 serde_json = "1.0"
@@ -37,7 +36,9 @@ force_graph = "0.3.2"
 rand = "0.8.5"
 futures = "0.3.21"
 edbm = {git = "https://github.com/Ecdar/EDBM"}
-
+log = "0.4.17"
+env_logger = {version = "0.9.0", optional = true }
+chrono = {version = "0.4.22", optional = true }
 
 # Enable optimizations for EDBM in debug mode, but not for our code:
 [profile.dev.package.edbm]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-name = "Reveaal"
+name = "reveaal"
 version = "0.1.0"
 build = "src/build.rs"
 authors = ["Peter Greve <Pgreve16@student.aau.dk>"]
 edition = "2018"
+
+[lib]
+name = "reveaal"
+path = "src/lib.rs"
 
 [features]
 dbm-stub = []
@@ -42,5 +46,9 @@ opt-level = 3
 [build-dependencies]
 tonic-build = "0.5.*"
 
+[dev-dependencies]
+criterion = "0.3.6"
 
-
+[[bench]]
+name = "bench"
+harness = false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a model checking engine for ECDAR (Environment for Compositional Design 
 The engine uses the ECDAR DBM Library for operations on zones of time (https://www.github.com/ECDAR/EDBM).
 
 ## Prerequisites 
-- A rust compiler installed (https://www.rust-lang.org/learn/get-started) 
+- A rust compiler installed (https://www.rust-lang.org/learn/get-started)
 - A folder containing the model components to check
 - ProtoBuf compiler protoc (for the Ubuntu linux distribution ```apt install protobuf-compiler```)
 - Download ProtoBuf definitions with ```git submodule update --init --recursive```
@@ -17,8 +17,8 @@ The engine uses the ECDAR DBM Library for operations on zones of time (https://w
 - Optionally run the tests using `cargo test`
 
 ## Cross compiling
-The project is pure just so one should be able to crosscompile to any platform with a rust target.
+The project is pure Rust so one should be able to crosscompile to any platform with a rust target.
 
 ### Compiling to Windows
-Ensure that the rustc windows target is installed with `rustup target add x86_64-pc-windows-gnu` and build with cargo:
+Make sure you have mingw installed `sudo apt-get install mingw-w64` and the rustc windows target is installed with `rustup target add x86_64-pc-windows-gnu` and build with cargo:
 `cargo build --target x86_64-pc-windows-gnu`

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use criterion::{criterion_group, criterion_main, Criterion};
 use reveaal::tests::refinement::Helper::json_refinement_check;
 
 static PATH: &str = "samples/json/EcdarUniversity";

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,60 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use reveaal::tests::refinement::Helper::json_refinement_check;
+
+static PATH: &str = "samples/json/EcdarUniversity";
+
+fn bench_refinement(c: &mut Criterion, query: &str) {
+    c.bench_function(query, |b| {
+        b.iter(|| {
+            assert!(json_refinement_check(PATH, &format!("refinement: {query}")));
+        })
+    });
+}
+
+fn bench_non_refinement(c: &mut Criterion, query: &str) {
+    c.bench_function(&format!("NOT {query}"), |b| {
+        b.iter(|| {
+            assert!(!json_refinement_check(
+                PATH,
+                &format!("refinement: {query}")
+            ));
+        })
+    });
+}
+
+fn bench_self_refinement(c: &mut Criterion, query: &str) {
+    bench_refinement(c, &format!("{query} <= {query}"));
+}
+
+fn self_refinement(c: &mut Criterion) {
+    bench_self_refinement(c, "Adm2");
+    bench_self_refinement(c, "Administration");
+    bench_self_refinement(c, "HalfAdm1");
+    bench_self_refinement(c, "HalfAdm2");
+    bench_self_refinement(c, "Machine");
+    bench_self_refinement(c, "Machine3");
+    bench_self_refinement(c, "Researcher");
+    bench_self_refinement(c, "Spec");
+
+    bench_self_refinement(c, "Administration || Researcher || Machine");
+}
+
+fn refinement(c: &mut Criterion) {
+    bench_refinement(c, "Researcher <= Spec // Administration // Machine");
+    bench_refinement(c, "Machine <= Spec // Administration // Researcher");
+    bench_refinement(c, "Administration <= Spec // Researcher // Machine");
+    bench_refinement(c, "Administration || Researcher <= Spec // Machine");
+    bench_refinement(c, "Researcher || Machine <= Spec // Administration");
+    bench_refinement(c, "Machine || Administration <= Spec // Researcher");
+}
+
+fn not_refinement(c: &mut Criterion) {
+    bench_non_refinement(c, "Adm2 <= Spec // Researcher // Machine");
+    bench_non_refinement(c, "Machine <= Spec // Adm2 // Researcher");
+    bench_non_refinement(c, "Adm2 || Researcher <= Spec // Machine");
+}
+
+criterion_group!(benches, self_refinement, refinement, not_refinement);
+
+criterion_main!(benches);

--- a/src/DataReader/serialization.rs
+++ b/src/DataReader/serialization.rs
@@ -219,10 +219,7 @@ where
                         }
                     }
                 } else {
-                    let mut error_string = "not implemented read for type: ".to_string();
-                    error_string.push_str(variable_type);
-                    println!("Variable type: {:?}", variable_type);
-                    panic!("{}", error_string);
+                    panic!("Not implemented read for type: \"{}\"", variable_type);
                 }
             }
         }

--- a/src/ModelObjects/system_declarations.rs
+++ b/src/ModelObjects/system_declarations.rs
@@ -1,4 +1,5 @@
 use crate::ModelObjects::component::Component;
+use log::debug;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
@@ -90,7 +91,7 @@ where
         if !declaration.is_empty() {
             if first_run {
                 let component_decls = &declaration;
-                println!("Comp decls: {component_decls}");
+                debug!("Comp decls: {component_decls}");
                 component_names = component_decls.split(' ').map(|s| s.into()).collect();
 
                 if component_names[0] == "system" {

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -1,6 +1,5 @@
 use std::panic::AssertUnwindSafe;
 
-use crate::debug_print;
 use crate::DataReader::json_writer::component_to_json;
 use crate::DataReader::parse_queries;
 use crate::ModelObjects::queries::Query;
@@ -12,6 +11,7 @@ use crate::ProtobufServer::services::query_response::{
 use crate::ProtobufServer::services::{Component, Query as ProtobufQuery, QueryResponse};
 use crate::System::executable_query::QueryResult;
 use crate::System::extract_system_rep;
+use log::trace;
 use tonic::{Request, Response, Status};
 
 use crate::ProtobufServer::ConcreteEcdarBackend;
@@ -21,7 +21,7 @@ impl ConcreteEcdarBackend {
         &self,
         request: AssertUnwindSafe<Request<ProtobufQuery>>,
     ) -> Result<Response<QueryResponse>, Status> {
-        debug_print!("Received query: {:?}", request);
+        trace!("Received query: {:?}", request);
         let query_request = request.0.into_inner();
 
         let query = parse_query(&query_request)?;

--- a/src/ProtobufServer/ecdar_requests/update_components.rs
+++ b/src/ProtobufServer/ecdar_requests/update_components.rs
@@ -1,4 +1,3 @@
-use crate::debug_print;
 use crate::DataReader::component_loader::ComponentContainer;
 use crate::DataReader::component_loader::ComponentLoader;
 use crate::DataReader::json_reader::json_to_component;
@@ -8,6 +7,7 @@ use crate::ProtobufServer::services::component::Rep;
 use crate::ProtobufServer::services::{Component as ProtobufComponent, ComponentsUpdateRequest};
 use crate::ProtobufServer::ConcreteEcdarBackend;
 use crate::System::input_enabler;
+use log::trace;
 use std::cell::RefCell;
 use std::panic::AssertUnwindSafe;
 use tonic::{Request, Response};
@@ -60,7 +60,7 @@ fn parse_xml_components(xml: &str) -> Vec<Component> {
 
 fn save_components(component_container: &RefCell<ComponentContainer>, components: Vec<Component>) {
     for mut component in components {
-        debug_print!("Adding comp {} to container", component.get_name());
+        trace!("Adding comp {} to container", component.get_name());
         component.create_edge_io_split();
         let inputs: Vec<_> = component
             .get_input_actions()

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -1,6 +1,7 @@
 use crate::ProtobufServer::services::ecdar_backend_server::EcdarBackendServer;
 use crate::ProtobufServer::ConcreteEcdarBackend;
 use core::time::Duration;
+use log::info;
 use tokio::runtime;
 use tonic::transport::Server;
 
@@ -16,7 +17,7 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<(), Box<dyn std
 }
 
 async fn start_grpc_server(ip_endpoint: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting grpc server on '{}'", ip_endpoint.trim());
+    info!("Starting grpc server on '{}'", ip_endpoint.trim());
 
     Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(120)))

--- a/src/Simulation/graph_layout.rs
+++ b/src/Simulation/graph_layout.rs
@@ -1,5 +1,6 @@
 use crate::DataReader::serialization::DummyComponent;
 use force_graph::{DefaultNodeIdx, ForceGraph, NodeData};
+use log::info;
 use rand::Rng;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -38,7 +39,7 @@ fn get_config() -> Config {
     match read_config("config.json") {
         Ok(config) => config,
         Err(_) => {
-            println!("Could not find graph layout config, using defaults");
+            info!("Could not find graph layout config, using defaults");
             Config::default()
         }
     }

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -1,4 +1,5 @@
 use edbm::util::constraints::ClockIndex;
+use log::info;
 
 use crate::DataReader::component_loader::ComponentLoader;
 use crate::ModelObjects::component::Component;
@@ -61,7 +62,7 @@ impl ExecutableQuery for RefinementExecutor {
 
         match refine::check_refinement(sys1, sys2) {
             Ok(res) => {
-                println!("Refinement result: {:?}", res);
+                info!("Refinement result: {:?}", res);
                 QueryResult::Refinement(res)
             }
             Err(err_msg) => QueryResult::Error(err_msg),

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -13,6 +13,7 @@ use crate::TransitionSystems::{
 
 use crate::System::pruning;
 use edbm::util::constraints::ClockIndex;
+use log::debug;
 use simple_error::bail;
 
 use std::error::Error;
@@ -145,7 +146,7 @@ pub fn get_system_recipe(
                 Some(q_i) => *q_i,
                 None => {
                     *clock_index += 1;
-                    println!("Quotient clock index: {}", *clock_index);
+                    debug!("Quotient clock index: {}", *clock_index);
 
                     quotient_index.replace(*clock_index);
                     quotient_index.unwrap()
@@ -157,7 +158,7 @@ pub fn get_system_recipe(
         QueryExpression::VarName(name) => {
             let mut component = component_loader.get_component(name).clone();
             component.set_clock_indices(clock_index);
-            println!("{} Clocks: {:?}", name, component.declarations.clocks);
+            debug!("{} Clocks: {:?}", name, component.declarations.clocks);
 
             Box::new(SystemRecipe::Component(Box::new(component)))
         }

--- a/src/System/local_consistency.rs
+++ b/src/System/local_consistency.rs
@@ -1,4 +1,5 @@
 use edbm::zones::OwnedFederation;
+use log::warn;
 
 use crate::ModelObjects::component::State;
 use crate::TransitionSystems::TransitionSystem;
@@ -12,7 +13,7 @@ pub fn is_least_consistent(system: &dyn TransitionSystem) -> bool {
     let mut passed = vec![];
     let state = system.get_initial_state();
     if state.is_none() {
-        println!("Empty initial state");
+        warn!("Empty initial state");
         return false;
     }
     let mut state = state.unwrap();
@@ -57,7 +58,7 @@ fn is_deterministic_helper(
                 let mut allowed_fed = transition.get_allowed_federation();
                 allowed_fed = state.decorated_locations.apply_invariants(allowed_fed);
                 if allowed_fed.has_intersection(&location_fed) {
-                    println!(
+                    warn!(
                         "Not deterministic from location {}",
                         state.get_location().id
                     );
@@ -85,7 +86,7 @@ pub fn is_fully_consistent(system: &dyn TransitionSystem) -> bool {
     let mut passed = vec![];
     let state = system.get_initial_state();
     if state.is_none() {
-        println!("Empty initial state");
+        warn!("Empty initial state");
         return false;
     }
     consistency_fully_helper(state.unwrap(), &mut passed, system)
@@ -114,7 +115,7 @@ pub fn consistency_least_helper(
             if transition.use_transition(&mut new_state) {
                 new_state.extrapolate_max_bounds(system);
                 if !consistency_least_helper(new_state, passed_list, system) {
-                    println!(
+                    warn!(
                         "Input \"{input}\" not consistent from {}",
                         state.get_location().id
                     );
@@ -140,7 +141,7 @@ pub fn consistency_least_helper(
             }
         }
     }
-    println!("No saving outputs from {}", state.get_location().id);
+    warn!("No saving outputs from {}", state.get_location().id);
 
     false
 }

--- a/src/System/pruning.rs
+++ b/src/System/pruning.rs
@@ -1,5 +1,6 @@
 use edbm::util::constraints::ClockIndex;
 use edbm::zones::OwnedFederation;
+use log::{debug, trace};
 
 use crate::EdgeEval::constraint_applyer::apply_constraints_to_state;
 use crate::ModelObjects::component::{
@@ -58,7 +59,7 @@ impl PruneContext {
 
     fn remove_edge(&mut self, edge: &Edge) {
         if let Some(index) = self.comp.edges.iter().position(|e| *e == *edge) {
-            println!("Removing {}", edge);
+            trace!("Removing {}", edge);
             self.comp.edges.remove(index);
             self.comp.create_edge_io_split();
         }
@@ -71,7 +72,7 @@ impl PruneContext {
                 &self.decl().clocks,
             );
 
-            println!(
+            trace!(
                 "Updating {} with guard {}",
                 edge,
                 guard.as_ref().unwrap_or(&BoolExpression::Bool(true))
@@ -105,7 +106,7 @@ pub fn prune(
         .map(|id| (id.clone(), OwnedFederation::universe(dim)))
         .collect();
 
-    println!("Inconsistent locs: {:?}", inconsistent_locs);
+    trace!("Inconsistent locs: {:?}", inconsistent_locs);
 
     let mut context = PruneContext {
         comp: new_comp,
@@ -130,7 +131,7 @@ pub fn prune(
             handle_output(edge, &mut context);
         }
 
-        println!(
+        trace!(
             "Step {}",
             context
                 .inconsistent_parts
@@ -143,7 +144,7 @@ pub fn prune(
     let (mut new_comp, incons_parts) = context.finish();
     add_inconsistent_parts_to_invariants(&mut new_comp, incons_parts, dim);
 
-    println!(
+    debug!(
         "Pruned component from {} edges to {} edges",
         comp.get_edges().len(),
         new_comp.get_edges().len()
@@ -502,7 +503,7 @@ fn is_immediately_inconsistent(
         None => false,
     };
     if res {
-        println!(
+        log::warn!(
             "loc: {} inv: {} inconsistent",
             loc.id,
             loc.get_invariants().unwrap()

--- a/src/TransitionSystems/common.rs
+++ b/src/TransitionSystems/common.rs
@@ -5,6 +5,7 @@ use edbm::{
     util::{bounds::Bounds, constraints::ClockIndex},
     zones::OwnedFederation,
 };
+use log::warn;
 
 use crate::ModelObjects::component::{Declarations, State, Transition};
 
@@ -78,12 +79,12 @@ impl<T: ComposedTransitionSystem> TransitionSystem for T {
 
     fn precheck_sys_rep(&self) -> bool {
         if !self.is_deterministic() {
-            println!("NOT DETERMINISTIC");
+            warn!("Not deterministic");
             return false;
         }
 
         if !self.is_locally_consistent() {
-            println!("NOT CONSISTENT");
+            warn!("Not consistent");
             return false;
         }
         true
@@ -99,7 +100,7 @@ impl<T: ComposedTransitionSystem> TransitionSystem for T {
         let mut zone = OwnedFederation::init(self.get_dim());
         zone = init_loc.apply_invariants(zone);
         if zone.is_empty() {
-            println!("Empty initial state");
+            warn!("Empty initial state");
             return None;
         }
 

--- a/src/TransitionSystems/compiled_component.rs
+++ b/src/TransitionSystems/compiled_component.rs
@@ -3,6 +3,7 @@ use crate::ModelObjects::component::{
 };
 use edbm::util::bounds::Bounds;
 use edbm::util::constraints::ClockIndex;
+use log::warn;
 
 use crate::System::local_consistency;
 use crate::TransitionSystems::{LocationTuple, TransitionSystem, TransitionSystemPtr};
@@ -170,12 +171,12 @@ impl TransitionSystem for CompiledComponent {
 
     fn precheck_sys_rep(&self) -> bool {
         if !self.is_deterministic() {
-            println!("NOT DETERMINISTIC");
+            warn!("Not deterministic");
             return false;
         }
 
         if !self.is_locally_consistent() {
-            println!("NOT CONSISTENT");
+            warn!("Not consistent");
             return false;
         }
         true

--- a/src/TransitionSystems/quotient.rs
+++ b/src/TransitionSystems/quotient.rs
@@ -1,5 +1,6 @@
 use edbm::util::constraints::ClockIndex;
 use edbm::zones::OwnedFederation;
+use log::{debug, warn};
 
 use crate::EdgeEval::updater::CompiledUpdate;
 use crate::ModelObjects::component::Declarations;
@@ -106,13 +107,13 @@ impl Quotient {
             .clocks
             .insert("quotient_xnew".to_string(), new_clock_index);
 
-        println!("S//T Inputs: {inputs:?}, Outputs: {outputs:?}");
-        println!(
+        debug!("S//T Inputs: {inputs:?}, Outputs: {outputs:?}");
+        debug!(
             "S Inputs: {:?}, Outputs: {:?}",
             S.get_input_actions(),
             S.get_output_actions()
         );
-        println!(
+        debug!(
             "T Inputs: {:?}, Outputs: {:?}",
             T.get_input_actions(),
             T.get_output_actions()
@@ -376,12 +377,12 @@ impl TransitionSystem for Quotient {
 
     fn precheck_sys_rep(&self) -> bool {
         if !self.is_deterministic() {
-            println!("NOT DETERMINISTIC");
+            warn!("Not deterministic");
             return false;
         }
 
         if !self.is_locally_consistent() {
-            println!("NOT CONSISTENT");
+            warn!("Not consistent");
             return false;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ProtobufServer;
 pub mod Simulation;
 pub mod System;
 pub mod TransitionSystems;
+pub(crate) mod logging;
 pub mod tests;
 
 pub use crate::DataReader::component_loader::{
@@ -28,17 +29,3 @@ extern crate serde;
 extern crate serde_xml_rs;
 extern crate simple_error;
 extern crate xml;
-
-// The debug version
-#[macro_export]
-#[cfg(feature = "verbose")]
-macro_rules! debug_print {
-    ($( $args:expr ),*) => { println!( $( $args ),* ); }
-}
-
-// Non-debug version
-#[macro_export]
-#[cfg(not(feature = "verbose"))]
-macro_rules! debug_print {
-    ($( $args:expr ),*) => {};
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,44 @@
+#![allow(non_snake_case)]
+pub mod DataReader;
+pub mod DataTypes;
+pub mod EdgeEval;
+pub mod ModelObjects;
+pub mod ProtobufServer;
+pub mod Simulation;
+pub mod System;
+pub mod TransitionSystems;
+pub mod tests;
+
+pub use crate::DataReader::component_loader::{
+    ComponentLoader, JsonProjectLoader, ProjectLoader, XmlProjectLoader,
+};
+pub use crate::DataReader::{parse_queries, xml_parser};
+pub use crate::ModelObjects::queries::Query;
+pub use crate::System::extract_system_rep;
+pub use ModelObjects::component;
+pub use ModelObjects::queries;
+pub use ProtobufServer::start_grpc_server_with_tokio;
+pub use System::executable_query::QueryResult;
+
+#[macro_use]
+extern crate pest_derive;
+extern crate colored;
+extern crate core;
+extern crate serde;
+extern crate serde_xml_rs;
+extern crate simple_error;
+extern crate xml;
+
+// The debug version
+#[macro_export]
+#[cfg(feature = "verbose")]
+macro_rules! debug_print {
+    ($( $args:expr ),*) => { println!( $( $args ),* ); }
+}
+
+// Non-debug version
+#[macro_export]
+#[cfg(not(feature = "verbose"))]
+macro_rules! debug_print {
+    ($( $args:expr ),*) => {};
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,31 @@
+use chrono::Local;
+use colored::{ColoredString, Colorize};
+use log::SetLoggerError;
+use std::io::Write;
+
+#[cfg(feature = "logging")]
+pub fn setup_logger() -> Result<(), SetLoggerError> {
+    fn colored_level(level: log::Level) -> ColoredString {
+        match level {
+            log::Level::Error => level.to_string().red(),
+            log::Level::Warn => level.to_string().yellow(),
+            log::Level::Info => level.to_string().cyan(),
+            log::Level::Debug => level.to_string().blue(),
+            log::Level::Trace => level.to_string().magenta(),
+        }
+    }
+
+    env_logger::Builder::from_env(env_logger::Env::default())
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "[{} {}:{} {}] - {}",
+                Local::now().format("%H:%M:%S").to_string().cyan(),
+                record.file().unwrap_or_default(),
+                record.line().unwrap_or_default(),
+                colored_level(record.level()),
+                record.args()
+            )
+        })
+        .try_init()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use clap::{load_yaml, App};
 mod logging;
 use logging::setup_logger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,9 @@
-#![allow(non_snake_case)]
-
-mod DataReader;
-mod DataTypes;
-mod EdgeEval;
-mod ModelObjects;
-mod ProtobufServer;
-mod Simulation;
-mod System;
-mod TransitionSystems;
-mod tests;
-
-use crate::DataReader::component_loader::{
-    ComponentLoader, JsonProjectLoader, ProjectLoader, XmlProjectLoader,
-};
-use crate::DataReader::{parse_queries, xml_parser};
-use crate::ModelObjects::queries::Query;
-use crate::System::extract_system_rep;
 use clap::{load_yaml, App};
+use reveaal::{
+    extract_system_rep, parse_queries, queries, start_grpc_server_with_tokio, xml_parser,
+    ComponentLoader, JsonProjectLoader, ProjectLoader, Query, QueryResult, XmlProjectLoader,
+};
 use std::env;
-use ModelObjects::component;
-use ModelObjects::queries;
-use ProtobufServer::start_grpc_server_with_tokio;
-use System::executable_query::QueryResult;
-
-#[macro_use]
-extern crate pest_derive;
-extern crate colored;
-extern crate core;
-extern crate serde;
-extern crate serde_xml_rs;
-extern crate simple_error;
-extern crate xml;
-
-// The debug version
-#[macro_export]
-#[cfg(feature = "verbose")]
-macro_rules! debug_print {
-    ($( $args:expr ),*) => { println!( $( $args ),* ); }
-}
-
-// Non-debug version
-#[macro_export]
-#[cfg(not(feature = "verbose"))]
-macro_rules! debug_print {
-    ($( $args:expr ),*) => {};
-}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let yaml = load_yaml!("cli.yml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 use clap::{load_yaml, App};
+mod logging;
+use logging::setup_logger;
+
 use reveaal::{
     extract_system_rep, parse_queries, queries, start_grpc_server_with_tokio, xml_parser,
     ComponentLoader, JsonProjectLoader, ProjectLoader, Query, QueryResult, XmlProjectLoader,
@@ -6,6 +9,9 @@ use reveaal::{
 use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "logging")]
+    setup_logger().unwrap();
+
     let yaml = load_yaml!("cli.yml");
     let matches = App::from(yaml).get_matches();
 
@@ -77,7 +83,6 @@ fn get_project_loader(project_path: String) -> Box<dyn ProjectLoader> {
 
 pub fn set_working_directory(folder_path: &str) {
     let mut path = std::path::Path::new(folder_path);
-    println!("env {}", path.to_str().unwrap());
     if path.is_file() {
         path = path
             .parent()

--- a/src/tests/refinement/Helper.rs
+++ b/src/tests/refinement/Helper.rs
@@ -1,10 +1,17 @@
+use crate::logging::setup_logger;
 use crate::DataReader::component_loader::{JsonProjectLoader, XmlProjectLoader};
 use crate::DataReader::parse_queries;
 use crate::ModelObjects::queries::Query;
 use crate::System::executable_query::QueryResult;
 use crate::System::extract_system_rep::create_executable_query;
 
+fn try_setup_logging() {
+    #[cfg(feature = "logging")]
+    let _ = setup_logger();
+}
+
 pub fn xml_refinement_check(PATH: &str, QUERY: &str) -> bool {
+    try_setup_logging();
     match xml_run_query(PATH, QUERY) {
         QueryResult::Refinement(result) => result,
         QueryResult::Error(err) => panic!("{}", err),
@@ -13,6 +20,8 @@ pub fn xml_refinement_check(PATH: &str, QUERY: &str) -> bool {
 }
 
 pub fn json_refinement_check(PATH: &str, QUERY: &str) -> bool {
+    try_setup_logging();
+
     match json_run_query(PATH, QUERY) {
         QueryResult::Refinement(result) => result,
         QueryResult::Error(err) => panic!("{}", err),

--- a/src/tests/refinement/mod.rs
+++ b/src/tests/refinement/mod.rs
@@ -1,7 +1,6 @@
 mod AG_Tests;
 mod Big_Refinement;
 mod Conjunction_refinement;
-#[cfg(test)]
 pub mod Helper;
 mod Refinement_delay_add;
 mod Refinement_university;


### PR DESCRIPTION
It is now possible to use Criterion benchmarking because of EDBM (we couldn't have both a library and binary target with UDBM, for unknown reasons).

This allows us to monitor the performance after small changes as criterion shows the difference since last run.

Benchmarking can be run with `cargo bench`
![image](https://user-images.githubusercontent.com/17483094/188685663-f4372ae2-cb74-47d3-82c1-7f12b6940740.png)
The benchmarking is not perfect as it is affected by external factors, e.g. background processes, laptop not plugged in, etc., but it is better than nothing.

Additionally adds logging, as in #94, with various logging levels that can be disabled and enabled: 
```rust
error!("Test");
warn!("Test");
info!("Test");
debug!("Test");
trace!("Test");
```
For more info on logging and options see #94.

Logging is necessary because output is not captured during benching, whereas the logger can be disabled. Without a (disabled) logger we could not see the benchmark results due to prints. My bad for not splitting it into two PRs.