### PR TITLE
Clock reduction fix

### DIFF
--- a/src/ModelObjects/component.rs
+++ b/src/ModelObjects/component.rs
@@ -187,13 +187,8 @@ impl Component {
             .expect("Couldn't find clock with index")
             .to_owned();
         self.declarations.clocks.remove(&name);
-        self.declarations
-            .clocks
-            .values_mut()
-            .filter(|val| **val > index)
-            .for_each(|val| *val -= 1);
 
-        // Yeets from updates
+        // Removes from from updates
         self.edges
             .iter_mut()
             .filter(|e| e.update.is_some())

--- a/src/System/executable_query.rs
+++ b/src/System/executable_query.rs
@@ -1,5 +1,3 @@
-use edbm::util::constraints::ClockIndex;
-
 use crate::DataReader::component_loader::ComponentLoader;
 use crate::ModelObjects::component::State;
 use crate::System::reachability;
@@ -7,7 +5,6 @@ use crate::System::refine;
 use crate::System::save_component::combine_components;
 use crate::TransitionSystems::TransitionSystemPtr;
 
-use super::extract_system_rep::SystemRecipe;
 use super::query_failures::PathFailure;
 use super::query_failures::QueryResult;
 use super::save_component::PruningStrategy;
@@ -122,16 +119,12 @@ impl<'a> ExecutableQuery for GetComponentExecutor<'a> {
 }
 
 pub struct ConsistencyExecutor {
-    pub recipe: Box<SystemRecipe>,
-    pub dim: ClockIndex,
+    pub system: TransitionSystemPtr,
 }
 
 impl ExecutableQuery for ConsistencyExecutor {
     fn execute(self: Box<Self>) -> QueryResult {
-        match self.recipe.compile(self.dim) {
-            Ok(system) => system.precheck_sys_rep().into(),
-            Err(fail) => fail.into(),
-        }
+        self.system.precheck_sys_rep().into()
     }
 }
 

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -471,7 +471,7 @@ pub(crate) mod clock_reduction {
             l: Vec<ClockReductionInstruction>,
             r: Vec<ClockReductionInstruction>,
             quotient: ClockIndex,
-            bound_predicate: P
+            bound_predicate: P,
         ) -> Vec<ClockReductionInstruction> {
             l.into_iter()
                 // Takes clock instructions that also occur in the rhs system
@@ -489,7 +489,9 @@ pub(crate) mod clock_reduction {
         }
         let quotient_clock = quotient_clock.unwrap_or_default();
         (
-            get_unique_redundant_clocks(lhs.clone(), rhs.clone(), quotient_clock, |c| c <= split_index),
+            get_unique_redundant_clocks(lhs.clone(), rhs.clone(), quotient_clock, |c| {
+                c <= split_index
+            }),
             get_unique_redundant_clocks(rhs, lhs, quotient_clock, |c| c > split_index),
         )
     }

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -108,8 +108,7 @@ pub fn create_executable_query<'a>(
                 }
 
                 Ok(Box::new(ConsistencyExecutor {
-                    recipe,
-                    dim
+                    system: recipe.compile(dim)?
                 }))
             },
             QueryExpression::Determinism(query_expression) => {

--- a/src/System/extract_system_rep.rs
+++ b/src/System/extract_system_rep.rs
@@ -401,7 +401,7 @@ pub(crate) mod clock_reduction {
         }
         let rhs = rhs.unwrap();
 
-        let (l_clocks, r_clocks) = sanitize_redundant_clocks(
+        let (l_clocks, r_clocks) = filter_redundant_clocks(
             lhs.clone().compile(*dim)?.find_redundant_clocks(),
             rhs.clone().compile(*dim)?.find_redundant_clocks(),
             quotient_clock,
@@ -458,7 +458,7 @@ pub(crate) mod clock_reduction {
         Ok(())
     }
 
-    fn sanitize_redundant_clocks(
+    fn filter_redundant_clocks(
         lhs: Vec<ClockReductionInstruction>,
         rhs: Vec<ClockReductionInstruction>,
         quotient_clock: Option<ClockIndex>,

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -183,10 +183,10 @@ pub trait TransitionSystem: DynClone {
     fn get_analysis_graph(&self) -> ClockAnalysisGraph {
         let mut graph: ClockAnalysisGraph = ClockAnalysisGraph::empty();
         graph.dim = self.get_dim();
-        let location = self.get_initial_location().unwrap();
         let actions = self.get_actions();
-
-        self.find_edges_and_nodes(&location, &actions, &mut graph);
+        for location in self.get_all_locations() {
+            self.find_edges_and_nodes(&location, &actions, &mut graph);
+        }
 
         graph
     }
@@ -240,15 +240,6 @@ pub trait TransitionSystem: DynClone {
                 }
 
                 graph.edges.push(edge);
-
-                //Calls itself on the transitions target location if the location is not already in
-                //represented as a node in the graph.
-                if !graph
-                    .nodes
-                    .contains_key(&transition.target_locations.id.get_unique_string())
-                {
-                    self.find_edges_and_nodes(&transition.target_locations, actions, graph);
-                }
             }
         }
     }

--- a/src/TransitionSystems/transition_system.rs
+++ b/src/TransitionSystems/transition_system.rs
@@ -304,10 +304,10 @@ impl ClockReductionInstruction {
         }
     }
 
-    pub(crate) fn is_replace(&self) -> bool {
+    pub(crate) fn get_clock_index(&self) -> ClockIndex {
         match self {
-            ClockReductionInstruction::RemoveClock { .. } => false,
-            ClockReductionInstruction::ReplaceClocks { .. } => true,
+            ClockReductionInstruction::RemoveClock { clock_index }
+            | ClockReductionInstruction::ReplaceClocks { clock_index, .. } => *clock_index,
         }
     }
 }

--- a/src/tests/ClockReduction/advanced_clock_removal_test.rs
+++ b/src/tests/ClockReduction/advanced_clock_removal_test.rs
@@ -18,7 +18,7 @@ pub mod test {
 
         let mut system_recipe_copy = Box::new(system_recipe);
 
-        clock_reduction::clock_reduce(&mut system_recipe_copy, None, &mut dimensions, false)
+        clock_reduction::clock_reduce(&mut system_recipe_copy, None, &mut dimensions, None)
             .unwrap();
 
         //We let it use the unreduced amount of dimensions so we can catch the error

--- a/src/tests/ClockReduction/clock_removal_test.rs
+++ b/src/tests/ClockReduction/clock_removal_test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 pub mod clock_removal_tests {
+    use crate::component::Component;
     use crate::DataReader::json_reader::read_json_component;
     use crate::TransitionSystems::{CompiledComponent, TransitionSystem};
     use std::collections::HashSet;
-    use crate::component::Component;
 
     #[test]
     fn test_check_declarations_unused_clocks_are_removed() {

--- a/src/tests/failure_message/actions_test.rs
+++ b/src/tests/failure_message/actions_test.rs
@@ -19,6 +19,8 @@ mod test {
             action: actual_action,
             system: actual_system,
         })) = json_run_query(PATH, "determinism: NonDeterministic1")
+            .ok()
+            .unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!(
@@ -38,6 +40,8 @@ mod test {
             state: actual_state,
             system: actual_system,
         })) = json_run_query(PATH, "consistency: NonConsistent")
+            .ok()
+            .unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!((expected_location), (actual_location));
@@ -61,6 +65,8 @@ mod test {
                 _,
             ),
         ))) = json_run_query(PATH, "refinement: NonDeterministic1 <= NonDeterministic2")
+            .ok()
+            .unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!(
@@ -85,6 +91,8 @@ mod test {
                 _,
             ),
         ))) = json_run_query(PATH, "refinement: NonConsistent <= CorrectComponent")
+            .ok()
+            .unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!((expected_location), (actual_location));

--- a/src/tests/failure_message/actions_test.rs
+++ b/src/tests/failure_message/actions_test.rs
@@ -18,9 +18,7 @@ mod test {
             state: actual_state,
             action: actual_action,
             system: actual_system,
-        })) = json_run_query(PATH, "determinism: NonDeterministic1")
-            .ok()
-            .unwrap()
+        })) = json_run_query(PATH, "determinism: NonDeterministic1").unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!(
@@ -39,9 +37,7 @@ mod test {
         if let QueryResult::Consistency(Err(ConsistencyFailure::InconsistentFrom {
             state: actual_state,
             system: actual_system,
-        })) = json_run_query(PATH, "consistency: NonConsistent")
-            .ok()
-            .unwrap()
+        })) = json_run_query(PATH, "consistency: NonConsistent").unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!((expected_location), (actual_location));
@@ -64,9 +60,7 @@ mod test {
                 }),
                 _,
             ),
-        ))) = json_run_query(PATH, "refinement: NonDeterministic1 <= NonDeterministic2")
-            .ok()
-            .unwrap()
+        ))) = json_run_query(PATH, "refinement: NonDeterministic1 <= NonDeterministic2").unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!(
@@ -90,9 +84,7 @@ mod test {
                 },
                 _,
             ),
-        ))) = json_run_query(PATH, "refinement: NonConsistent <= CorrectComponent")
-            .ok()
-            .unwrap()
+        ))) = json_run_query(PATH, "refinement: NonConsistent <= CorrectComponent").unwrap()
         {
             let actual_location = actual_state.locations;
             assert_eq!((expected_location), (actual_location));

--- a/src/tests/failure_message/consistency_test.rs
+++ b/src/tests/failure_message/consistency_test.rs
@@ -10,7 +10,9 @@ mod test {
 
     #[test]
     fn not_consistent_test() {
-        let actual = json_run_query(PATH, "consistency: notConsistent");
+        let actual = json_run_query(PATH, "consistency: notConsistent")
+            .ok()
+            .unwrap();
         assert!(matches!(
             actual,
             QueryResult::Consistency(ConsistencyResult::Err(

--- a/src/tests/failure_message/consistency_test.rs
+++ b/src/tests/failure_message/consistency_test.rs
@@ -10,9 +10,7 @@ mod test {
 
     #[test]
     fn not_consistent_test() {
-        let actual = json_run_query(PATH, "consistency: notConsistent")
-            .ok()
-            .unwrap();
+        let actual = json_run_query(PATH, "consistency: notConsistent").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Consistency(ConsistencyResult::Err(

--- a/src/tests/failure_message/determinism_test.rs
+++ b/src/tests/failure_message/determinism_test.rs
@@ -12,18 +12,14 @@ mod test {
 
     #[test]
     fn determinism_failure_test() {
-        let actual = json_run_query(PATH, "determinism: NonDeterminismCom")
-            .ok()
-            .unwrap();
+        let actual = json_run_query(PATH, "determinism: NonDeterminismCom").unwrap();
 
         assert!(matches!(actual, QueryResult::Determinism(Err(_))));
     }
 
     #[test]
     fn determinism_failure_in_refinement_test() {
-        let actual = json_run_query(PATH, "refinement: NonDeterminismCom <= Component2")
-            .ok()
-            .unwrap();
+        let actual = json_run_query(PATH, "refinement: NonDeterminismCom <= Component2").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(

--- a/src/tests/failure_message/determinism_test.rs
+++ b/src/tests/failure_message/determinism_test.rs
@@ -12,14 +12,18 @@ mod test {
 
     #[test]
     fn determinism_failure_test() {
-        let actual = json_run_query(PATH, "determinism: NonDeterminismCom");
+        let actual = json_run_query(PATH, "determinism: NonDeterminismCom")
+            .ok()
+            .unwrap();
 
         assert!(matches!(actual, QueryResult::Determinism(Err(_))));
     }
 
     #[test]
     fn determinism_failure_in_refinement_test() {
-        let actual = json_run_query(PATH, "refinement: NonDeterminismCom <= Component2");
+        let actual = json_run_query(PATH, "refinement: NonDeterminismCom <= Component2")
+            .ok()
+            .unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(

--- a/src/tests/failure_message/refinement_test.rs
+++ b/src/tests/failure_message/refinement_test.rs
@@ -12,7 +12,7 @@ mod test {
 
     #[test]
     fn not_empty_result_test() {
-        let actual = json_run_query(PATH, "refinement: A <= B");
+        let actual = json_run_query(PATH, "refinement: A <= B").ok().unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CannotMatch { .. }))
@@ -21,7 +21,7 @@ mod test {
 
     #[test]
     fn empty_transition2s_test() {
-        let actual = json_run_query(PATH, "refinement: A <= A2");
+        let actual = json_run_query(PATH, "refinement: A <= A2").ok().unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CannotMatch { .. }))
@@ -30,7 +30,7 @@ mod test {
 
     #[test]
     fn cuts_delay_solutions_test() {
-        let actual = json_run_query(PATH, "refinement: A2 <= B2");
+        let actual = json_run_query(PATH, "refinement: A2 <= B2").ok().unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CutsDelaySolutions { .. }))
@@ -39,7 +39,7 @@ mod test {
 
     #[test]
     fn initial_state_test() {
-        let actual = json_run_query(PATH, "refinement: C <= D");
+        let actual = json_run_query(PATH, "refinement: C <= D").ok().unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(
@@ -53,7 +53,9 @@ mod test {
         let actual = json_run_query(
             PATH,
             "refinement: notDisjointAndNotSubset1 <= notDisjointAndNotSubset2",
-        );
+        )
+        .ok()
+        .unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(
@@ -64,7 +66,9 @@ mod test {
 
     #[test]
     fn not_subset_test() {
-        let actual = json_run_query(PATH, "refinement: notSubset1 <= notSubset2");
+        let actual = json_run_query(PATH, "refinement: notSubset1 <= notSubset2")
+            .ok()
+            .unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(
@@ -75,7 +79,9 @@ mod test {
 
     #[test]
     fn not_disjoint_test() {
-        let actual = json_run_query(PATH, "refinement: disJoint2 <= disJoint1");
+        let actual = json_run_query(PATH, "refinement: disJoint2 <= disJoint1")
+            .ok()
+            .unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(

--- a/src/tests/failure_message/refinement_test.rs
+++ b/src/tests/failure_message/refinement_test.rs
@@ -12,7 +12,7 @@ mod test {
 
     #[test]
     fn not_empty_result_test() {
-        let actual = json_run_query(PATH, "refinement: A <= B").ok().unwrap();
+        let actual = json_run_query(PATH, "refinement: A <= B").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CannotMatch { .. }))
@@ -21,7 +21,7 @@ mod test {
 
     #[test]
     fn empty_transition2s_test() {
-        let actual = json_run_query(PATH, "refinement: A <= A2").ok().unwrap();
+        let actual = json_run_query(PATH, "refinement: A <= A2").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CannotMatch { .. }))
@@ -30,7 +30,7 @@ mod test {
 
     #[test]
     fn cuts_delay_solutions_test() {
-        let actual = json_run_query(PATH, "refinement: A2 <= B2").ok().unwrap();
+        let actual = json_run_query(PATH, "refinement: A2 <= B2").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::CutsDelaySolutions { .. }))
@@ -39,7 +39,7 @@ mod test {
 
     #[test]
     fn initial_state_test() {
-        let actual = json_run_query(PATH, "refinement: C <= D").ok().unwrap();
+        let actual = json_run_query(PATH, "refinement: C <= D").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(
@@ -54,7 +54,6 @@ mod test {
             PATH,
             "refinement: notDisjointAndNotSubset1 <= notDisjointAndNotSubset2",
         )
-        .ok()
         .unwrap();
         assert!(matches!(
             actual,
@@ -79,9 +78,7 @@ mod test {
 
     #[test]
     fn not_disjoint_test() {
-        let actual = json_run_query(PATH, "refinement: disJoint2 <= disJoint1")
-            .ok()
-            .unwrap();
+        let actual = json_run_query(PATH, "refinement: disJoint2 <= disJoint1").unwrap();
         assert!(matches!(
             actual,
             QueryResult::Refinement(Err(RefinementFailure::Precondition(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,5 +14,5 @@ pub mod system_recipe;
 
 /// The default settings for Testing
 pub const TEST_SETTINGS: Settings = Settings {
-    disable_clock_reduction: true,
+    disable_clock_reduction: false,
 };

--- a/src/tests/reachability/search_algorithm_test.rs
+++ b/src/tests/reachability/search_algorithm_test.rs
@@ -28,7 +28,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH, "reachability: Researcher && Researcher -> [U0, U0](); [L6, U0]()", false; "Trivially unreachable")]
     #[test_case(PATH, "reachability: Researcher && Researcher -> [U0, U0](); [_, U0]()", true; "Trivially reachable because _ is U0")]
     fn search_algorithm_returns_result_university(path: &str, query: &str, expected: bool) {
-        match json_run_query(path, query) {
+        match json_run_query(path, query).ok().unwrap() {
             QueryResult::Reachability(path) => assert_eq!(path.is_ok(), expected),
             _ => panic!("Inconsistent query result, expected Reachability"),
         }
@@ -50,7 +50,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH2, "reachability: Component7 -> [L16](); [L19](y<2)", false; "Unreachable due to second clock")]
     #[test_case(PATH2, "reachability: Component3 && Component3 -> [L6, L6](); [L7, L7]()", true; "Simple conjunction")]
     fn search_algorithm_returns_result(path: &str, query: &str, expected: bool) {
-        match json_run_query(path, query) {
+        match json_run_query(path, query).ok().unwrap() {
             QueryResult::Reachability(path) => assert_eq!(path.is_ok(), expected),
             _ => panic!("Inconsistent query result, expected Reachability"),
         }
@@ -66,7 +66,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH2, "reachability: Component9 -> [L23](x>5); [L26]()", vec!["E17", "E18"]; "Path in Component9 from L23 x gt 5 to L26")]
     #[test_case(PATH2, "reachability: Component9 -> [L23](x<5); [L26]()", vec!["E16", "E19"]; "Path in Component9 from L23 x lt 5 to L26")]
     fn path_gen_test_correct_path(folder_path: &str, query: &str, expected_path: Vec<&str>) {
-        match json_run_query(folder_path, query) {
+        match json_run_query(folder_path, query).ok().unwrap() {
             QueryResult::Reachability(actual_path) => {
                 let actual_path = actual_path.unwrap_or_else(|_| {
                     panic!(
@@ -103,7 +103,7 @@ mod reachability_search_algorithm_test {
         query: &str,
         expected_path: Vec<Vec<&str>>,
     ) {
-        match json_run_query(folder_path, query) {
+        match json_run_query(folder_path, query).ok().unwrap() {
             QueryResult::Reachability(actual_path) => {
                 let actual_path = actual_path.unwrap_or_else(|_| {
                     panic!(

--- a/src/tests/reachability/search_algorithm_test.rs
+++ b/src/tests/reachability/search_algorithm_test.rs
@@ -28,7 +28,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH, "reachability: Researcher && Researcher -> [U0, U0](); [L6, U0]()", false; "Trivially unreachable")]
     #[test_case(PATH, "reachability: Researcher && Researcher -> [U0, U0](); [_, U0]()", true; "Trivially reachable because _ is U0")]
     fn search_algorithm_returns_result_university(path: &str, query: &str, expected: bool) {
-        match json_run_query(path, query).ok().unwrap() {
+        match json_run_query(path, query).unwrap() {
             QueryResult::Reachability(path) => assert_eq!(path.is_ok(), expected),
             _ => panic!("Inconsistent query result, expected Reachability"),
         }
@@ -50,7 +50,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH2, "reachability: Component7 -> [L16](); [L19](y<2)", false; "Unreachable due to second clock")]
     #[test_case(PATH2, "reachability: Component3 && Component3 -> [L6, L6](); [L7, L7]()", true; "Simple conjunction")]
     fn search_algorithm_returns_result(path: &str, query: &str, expected: bool) {
-        match json_run_query(path, query).ok().unwrap() {
+        match json_run_query(path, query).unwrap() {
             QueryResult::Reachability(path) => assert_eq!(path.is_ok(), expected),
             _ => panic!("Inconsistent query result, expected Reachability"),
         }
@@ -66,7 +66,7 @@ mod reachability_search_algorithm_test {
     #[test_case(PATH2, "reachability: Component9 -> [L23](x>5); [L26]()", vec!["E17", "E18"]; "Path in Component9 from L23 x gt 5 to L26")]
     #[test_case(PATH2, "reachability: Component9 -> [L23](x<5); [L26]()", vec!["E16", "E19"]; "Path in Component9 from L23 x lt 5 to L26")]
     fn path_gen_test_correct_path(folder_path: &str, query: &str, expected_path: Vec<&str>) {
-        match json_run_query(folder_path, query).ok().unwrap() {
+        match json_run_query(folder_path, query).unwrap() {
             QueryResult::Reachability(actual_path) => {
                 let actual_path = actual_path.unwrap_or_else(|_| {
                     panic!(
@@ -103,7 +103,7 @@ mod reachability_search_algorithm_test {
         query: &str,
         expected_path: Vec<Vec<&str>>,
     ) {
-        match json_run_query(folder_path, query).ok().unwrap() {
+        match json_run_query(folder_path, query).unwrap() {
             QueryResult::Reachability(actual_path) => {
                 let actual_path = actual_path.unwrap_or_else(|_| {
                     panic!(

--- a/src/tests/refinement/Helper.rs
+++ b/src/tests/refinement/Helper.rs
@@ -26,7 +26,7 @@ pub fn xml_refinement_check(PATH: &str, QUERY: &str) -> bool {
 pub fn json_refinement_check(PATH: &str, QUERY: &str) -> bool {
     try_setup_logging();
 
-    match json_run_query(PATH, QUERY).ok().unwrap() {
+    match json_run_query(PATH, QUERY).unwrap() {
         QueryResult::Refinement(Ok(())) => true,
         QueryResult::Refinement(Err(_)) => false,
         QueryResult::CustomError(err) => panic!("{}", err),

--- a/src/tests/system_recipe/compiled_component.rs
+++ b/src/tests/system_recipe/compiled_component.rs
@@ -3,19 +3,22 @@
 mod test {
     use std::collections::HashSet;
 
+    use crate::extract_system_rep::ExecutableQueryError;
     use crate::{
         tests::refinement::Helper::json_run_query,
-        System::query_failures::{ActionFailure, QueryResult, SystemRecipeFailure},
+        System::query_failures::{ActionFailure, SystemRecipeFailure},
     };
 
     const PATH: &str = "samples/json/SystemRecipe/CompiledComponent";
 
     #[test]
     fn compiled_component1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent1");
+        let actual = json_run_query(PATH, "consistency: CompiledComponent1")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -25,10 +28,10 @@ mod test {
     #[test]
     fn compiled_component1_fails_with_correct_actions() {
         let expected_actions: HashSet<_> = HashSet::from(["Input".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: CompiledComponent1")
+        ))) = json_run_query(PATH, "consistency: CompiledComponent1").err()
         {
             assert_eq!(
                 left.actions
@@ -44,10 +47,12 @@ mod test {
 
     #[test]
     fn compiled_component2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent2");
+        let actual = json_run_query(PATH, "consistency: CompiledComponent2")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -57,10 +62,10 @@ mod test {
     #[test]
     fn compiled_component2_fails_with_correct_actions() {
         let expected_actions: HashSet<_> = HashSet::from(["Input1".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: CompiledComponent2")
+        ))) = json_run_query(PATH, "consistency: CompiledComponent2").err()
         {
             assert_eq!(
                 left.actions
@@ -76,10 +81,12 @@ mod test {
 
     #[test]
     fn compiled_component3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent3");
+        let actual = json_run_query(PATH, "consistency: CompiledComponent3")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -90,10 +97,10 @@ mod test {
     fn compiled_component3_fails_with_correct_actions() {
         let expected_actions: HashSet<_> =
             HashSet::from(["Input1".to_string(), "Input2".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: CompiledComponent3")
+        ))) = json_run_query(PATH, "consistency: CompiledComponent3").err()
         {
             assert_eq!(
                 left.actions

--- a/src/tests/system_recipe/compiled_component.rs
+++ b/src/tests/system_recipe/compiled_component.rs
@@ -13,9 +13,7 @@ mod test {
 
     #[test]
     fn compiled_component1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent1")
-            .err()
-            .unwrap();
+        let actual = json_run_query(PATH, "consistency: CompiledComponent1").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -47,9 +45,7 @@ mod test {
 
     #[test]
     fn compiled_component2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent2")
-            .err()
-            .unwrap();
+        let actual = json_run_query(PATH, "consistency: CompiledComponent2").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -81,9 +77,7 @@ mod test {
 
     #[test]
     fn compiled_component3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: CompiledComponent3")
-            .err()
-            .unwrap();
+        let actual = json_run_query(PATH, "consistency: CompiledComponent3").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(

--- a/src/tests/system_recipe/composition.rs
+++ b/src/tests/system_recipe/composition.rs
@@ -13,9 +13,8 @@ mod test {
 
     #[test]
     fn compostion1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -47,9 +46,8 @@ mod test {
 
     #[test]
     fn compostion2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -81,9 +79,8 @@ mod test {
 
     #[test]
     fn compostion3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(

--- a/src/tests/system_recipe/composition.rs
+++ b/src/tests/system_recipe/composition.rs
@@ -3,19 +3,22 @@
 mod test {
     use std::collections::HashSet;
 
+    use crate::extract_system_rep::ExecutableQueryError;
     use crate::{
         tests::refinement::Helper::json_run_query,
-        System::query_failures::{ActionFailure, QueryResult, SystemRecipeFailure},
+        System::query_failures::{ActionFailure, SystemRecipeFailure},
     };
 
     const PATH: &str = "samples/json/SystemRecipe/Composition";
 
     #[test]
     fn compostion1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1");
+        let actual = json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -25,10 +28,10 @@ mod test {
     #[test]
     fn composition1_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Output1".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1")
+        ))) = json_run_query(PATH, "consistency: LeftComposition1 || RightComposition1").err()
         {
             assert_eq!(
                 left.actions
@@ -44,10 +47,12 @@ mod test {
 
     #[test]
     fn compostion2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2");
+        let actual = json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -57,10 +62,10 @@ mod test {
     #[test]
     fn composition2_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Output1".to_string(), "Output2".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2")
+        ))) = json_run_query(PATH, "consistency: LeftComposition2 || RightComposition2").err()
         {
             assert_eq!(
                 left.actions
@@ -76,10 +81,12 @@ mod test {
 
     #[test]
     fn compostion3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3");
+        let actual = json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -89,10 +96,10 @@ mod test {
     #[test]
     fn composition3_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Output2".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3")
+        ))) = json_run_query(PATH, "consistency: LeftComposition3 || RightComposition3").err()
         {
             assert_eq!(
                 left.actions

--- a/src/tests/system_recipe/conjunction.rs
+++ b/src/tests/system_recipe/conjunction.rs
@@ -13,9 +13,8 @@ mod test {
 
     #[test]
     fn conjunction1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -47,9 +46,8 @@ mod test {
 
     #[test]
     fn conjunction2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -81,9 +79,8 @@ mod test {
 
     #[test]
     fn conjunction3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(

--- a/src/tests/system_recipe/conjunction.rs
+++ b/src/tests/system_recipe/conjunction.rs
@@ -5,17 +5,20 @@ mod test {
 
     use crate::{
         tests::refinement::Helper::json_run_query,
-        System::query_failures::{ActionFailure, QueryResult, SystemRecipeFailure},
+        System::extract_system_rep::ExecutableQueryError,
+        System::query_failures::{ActionFailure, SystemRecipeFailure},
     };
 
     const PATH: &str = "samples/json/SystemRecipe/Conjunction";
 
     #[test]
     fn conjunction1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1");
+        let actual = json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -25,10 +28,10 @@ mod test {
     #[test]
     fn conjunction1_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Input1".to_string()]); // Assuming inputs are checked first
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1")
+        ))) = json_run_query(PATH, "consistency: LeftConjunction1 && RightConjunction1").err()
         {
             assert_eq!(
                 left.actions
@@ -44,10 +47,12 @@ mod test {
 
     #[test]
     fn conjunction2_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2");
+        let actual = json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -57,10 +62,10 @@ mod test {
     #[test]
     fn conjunction2_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Input1".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2")
+        ))) = json_run_query(PATH, "consistency: LeftConjunction2 && RightConjunction2").err()
         {
             assert_eq!(
                 left.actions
@@ -76,10 +81,12 @@ mod test {
 
     #[test]
     fn conjunction3_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3");
+        let actual = json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -89,10 +96,10 @@ mod test {
     #[test]
     fn conjunction3_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Output1".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3")
+        ))) = json_run_query(PATH, "consistency: LeftConjunction3 && RightConjunction3").err()
         {
             assert_eq!(
                 left.actions

--- a/src/tests/system_recipe/quotient.rs
+++ b/src/tests/system_recipe/quotient.rs
@@ -5,8 +5,9 @@ mod test {
 
     use crate::{
         tests::refinement::Helper::json_run_query,
+        System::extract_system_rep::ExecutableQueryError,
         System::query_failures::{
-            ActionFailure, ConsistencyFailure, DeterminismFailure, QueryResult, SystemRecipeFailure,
+            ActionFailure, ConsistencyFailure, DeterminismFailure, SystemRecipeFailure,
         },
     };
 
@@ -14,10 +15,12 @@ mod test {
 
     #[test]
     fn quotient1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1");
+        let actual = json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1")
+            .err()
+            .unwrap();
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
                 ActionFailure::NotDisjoint(_, _),
                 _
             ))
@@ -27,10 +30,10 @@ mod test {
     #[test]
     fn quotient1_fails_with_correct_actions() {
         let expected_actions = HashSet::from(["Input1".to_string()]);
-        if let QueryResult::RecipeFailure(SystemRecipeFailure::Action(
+        if let Some(ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
             ActionFailure::NotDisjoint(left, right),
             _,
-        )) = json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1")
+        ))) = json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1").err()
         {
             assert_eq!(
                 left.actions
@@ -49,11 +52,13 @@ mod test {
         let actual = json_run_query(
             PATH,
             "consistency: NotDeterministicQuotientComp // DeterministicQuotientComp",
-        );
+        )
+        .err()
+        .unwrap();
         println!("{:?}", actual);
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Inconsistent(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Inconsistent(
                 ConsistencyFailure::NotDeterministic(DeterminismFailure { .. }),
                 _
             ))
@@ -65,11 +70,13 @@ mod test {
         let actual = json_run_query(
             PATH,
             "consistency: DeterministicQuotientComp // NotDeterministicQuotientComp",
-        );
+        )
+        .err()
+        .unwrap();
         println!("{:?}", actual);
         assert!(matches!(
             actual,
-            QueryResult::RecipeFailure(SystemRecipeFailure::Inconsistent(
+            ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Inconsistent(
                 ConsistencyFailure::NotDeterministic(DeterminismFailure { .. }),
                 _
             ))

--- a/src/tests/system_recipe/quotient.rs
+++ b/src/tests/system_recipe/quotient.rs
@@ -15,9 +15,8 @@ mod test {
 
     #[test]
     fn quotient1_fails_correctly() {
-        let actual = json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1")
-            .err()
-            .unwrap();
+        let actual =
+            json_run_query(PATH, "consistency: LeftQuotient1 // RightQuotient1").unwrap_err();
         assert!(matches!(
             actual,
             ExecutableQueryError::SystemRecipeFailure(SystemRecipeFailure::Action(
@@ -53,8 +52,7 @@ mod test {
             PATH,
             "consistency: NotDeterministicQuotientComp // DeterministicQuotientComp",
         )
-        .err()
-        .unwrap();
+        .unwrap_err();
         println!("{:?}", actual);
         assert!(matches!(
             actual,
@@ -71,8 +69,7 @@ mod test {
             PATH,
             "consistency: DeterministicQuotientComp // NotDeterministicQuotientComp",
         )
-        .err()
-        .unwrap();
+        .unwrap_err();
         println!("{:?}", actual);
         assert!(matches!(
             actual,


### PR DESCRIPTION
Before, the clock reduction could not handle queries such as `"refinement: A <= A" -i samples/json/AG ` where `A` has unused clocks within it. It would panic, trying to remove clocks on the left side of the expression, tat where actually found on the right side. This PR provides a fix to that.

Beyond that, when I created the tests, some other tests were panicking. This was because they expected an `Ok` from `create_executable_query` with a failure withing, but clock reduction compiles the system and returns the failure in `Err` if one is found. The reason for this is because these tests used `ConsistencyExecutor`, which has teh only struct implementing `ExecutableQuery` that took a `SystemRecipe` and compiled the system itself instead of taking a `TransitionSystemPtr`.
Therefore, I have refactored that, and a helper-function (`json_run_query`) in the tests so we can return the failure when performing clock reduction, instead of when executing the query. This involved a good portion of refactoring (hence the size of the PR), however it is mostly adapting the usage of said helper function