### PR TITLE
Minor fix for the DummyEdge

### DIFF
--- a/src/DataReader/serialization.rs
+++ b/src/DataReader/serialization.rs
@@ -33,6 +33,7 @@ impl DummyNail {
 
 #[derive(Serialize)]
 pub struct DummyEdge {
+    pub id: String,
     #[serde(rename = "sourceLocation")]
     pub source_location: String,
     #[serde(rename = "targetLocation")]
@@ -77,6 +78,7 @@ impl From<Edge> for DummyEdge {
         }
 
         DummyEdge {
+            id: item.id,
             source_location: item.source_location,
             target_location: item.target_location,
             sync_type: item.sync_type,


### PR DESCRIPTION
The `id` of the `Edge`s where not included in the serialization (relevant for `get-component` queries). This PR fixes that.