### PR TITLE
Replaced old protobuf submodule with forked version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "Ecdar-ProtoBuf"]
-	path = Ecdar-ProtoBuf
-	url = https://github.com/Ecdar/Ecdar-ProtoBuf.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Ecdar-ProtoBuf"]
+	path = Ecdar-ProtoBuf
+	url = https://github.com/ECDAR-AAU-SW-P5/Ecdar-ProtoBuf.git


### PR DESCRIPTION
This forked version of Reveaal uses the original Ecdar-ProtoBuf repo as a submodule.
We have recently forked the Ecdar-ProtoBuf repo as well.

This PR will make use of the new forked Ecdar-ProtoBuf repo instead,
allowing us to push new changes to the protobuffers.

**If you have already cloned Reveaal and pulled these changes**, you need to sync your submodules:

- `git submodule sync`